### PR TITLE
#49/#51 fixups: remove redundant eventtype, javadoc fix

### DIFF
--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -163,7 +163,7 @@ public class NakadiProducerAutoConfiguration {
     }
 
     private Snapshot mapLegacyToNewSnapshot(SnapshotEventProvider.Snapshot snapshot) {
-        return new Snapshot(snapshot.getId(), snapshot.getEventType(), snapshot.getDataType(), snapshot.getData());
+        return new Snapshot(snapshot.getId(), snapshot.getDataType(), snapshot.getData());
     }
 
     @Bean

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
@@ -26,9 +26,10 @@ public class Fixture {
     }
 
     public static List<Snapshot> mockSnapshotList(Integer size) {
-        List<Snapshot> list = new ArrayList<>();
+        final List<Snapshot> list = new ArrayList<>();
         for (int i = 0; i < size; i++) {
-            list.add(new Snapshot(i, PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, mockPayload(i + 1, "code" + i, true, mockSubClass("some info " + i), mockSubList(3, "some detail for code" + i))));
+            list.add(new Snapshot(i, PUBLISHER_DATA_TYPE, mockPayload(i + 1, "code" + i, true,
+                    mockSubClass("some info " + i), mockSubList(3, "some detail for code" + i))));
         }
         return list;
     }
@@ -46,7 +47,7 @@ public class Fixture {
     }
 
     public static List<MockPayload.SubListItem> mockSubList(Integer size, String detail) {
-        List<MockPayload.SubListItem> items = new ArrayList<>();
+        final List<MockPayload.SubListItem> items = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             items.add(mockSubListItem(detail + i));
         }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/Snapshot.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/Snapshot.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @Getter
 public class Snapshot {
     private Object id;
-    private String eventType;
     private String dataType;
     private Object data;
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerator.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerator.java
@@ -40,10 +40,13 @@ public interface SnapshotEventGenerator {
      *
      * @param filter
      *            a filter for the snapshot generation mechanism. This value is
-     *            simply passed through from the REST endpoint (or other
-     *            triggering mechanism), so implementations can interpret it in
-     *            whatever way you want (even ignore it). All calls for one
-     *            snapshot generation will receive the same string.
+     *            simply passed through from the request body of the REST
+     *            endpoint (or from any other triggering mechanism). If there
+     *            was no request body, this will be {@code null}.
+     *
+     *            Implementors can interpret it in whatever way they want (even
+     *            ignore it). All calls for one snapshot generation will receive
+     *            the same string.
      *
      * @return list of elements (wrapped in Snapshot objects) ordered by their
      *         ID.

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationServiceTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationServiceTest.java
@@ -62,7 +62,7 @@ public class SnapshotCreationServiceTest {
         final String filter = "exampleFilter";
 
         when(snapshotEventGenerator.generateSnapshots(null, filter)).thenReturn(
-                singletonList(new Snapshot(1, PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload)));
+                singletonList(new Snapshot(1, PUBLISHER_DATA_TYPE, eventPayload)));
 
         snapshotCreationService.createSnapshotEvents(PUBLISHER_EVENT_TYPE, filter);
 

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
@@ -26,9 +26,10 @@ public class Fixture {
     }
 
     public static List<Snapshot> mockSnapshotList(Integer size) {
-        List<Snapshot> list = new ArrayList<>();
+        final List<Snapshot> list = new ArrayList<>();
         for (int i = 0; i < size; i++) {
-            list.add(new Snapshot(i, PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, mockPayload(i + 1, "code" + i, true, mockSubClass("some info " + i), mockSubList(3, "some detail for code" + i))));
+            list.add(new Snapshot(i, PUBLISHER_DATA_TYPE, mockPayload(i + 1, "code" + i, true,
+                    mockSubClass("some info " + i), mockSubList(3, "some detail for code" + i))));
         }
         return list;
     }
@@ -46,7 +47,7 @@ public class Fixture {
     }
 
     public static List<MockPayload.SubListItem> mockSubList(Integer size, String detail) {
-        List<MockPayload.SubListItem> items = new ArrayList<>();
+        final List<MockPayload.SubListItem> items = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             items.add(mockSubListItem(detail + i));
         }


### PR DESCRIPTION
Small fixups for previous pull requests (which are not yet released, so this doesn't break anything):

* #49: remove the event type from the new Snapshot class (not the old nested one in the deprecated SnapshotEventProvider, though).
* #51: add a sentence about the behavior id the request body is null to the javadoc.