### PR TITLE
Mention scheduling disabling for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,10 @@ public class MyIT {
     }
 }
 ```
-The example above uses `com.jayway.jsonpath:json-path:jar:2.2.0` to parse and test the json results
+The example above uses `com.jayway.jsonpath:json-path:jar:2.2.0` to parse and test the json results.
+
+Note that you should disable the scheduled event transmission for the test (e.g. by setting `nakadi-producer.scheduled-transmission-enabled:false`), as that might interfere with the manual transmission and the clearing in the test setup, leading to events from one test showing up in the next test, depending on timing issues.
+
 ## Build
 
 Build with unit tests and integration tests:


### PR DESCRIPTION
That fact did cost me at least a full working day (with help from some colleagues).

While writing this comment I noted that the test quoted above this does not work as-is – i.e. the `@Autowired` will only work if you run this with a spring runner. Should we make this test fully working?