### PR TITLE
#70: use stable dependency version for tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ This library also uses:
 
 * flyway-core
 * Spring JDBC
-* [fahrschein](https://github.com/zalando-incubator/fahrschein) Nakadi client library
+* [fahrschein](https://github.com/zalando-nakadi/fahrschein) Nakadi client library
 * jackson >= 2.7.0
-* (optional) Zalando's tracer-spring-boot-starter
-* (optional) Zalando's tokens library >= 0.10.0
+* (optional) Zalando's [tracer-spring-boot-starter](https://github.com/zalando/tracer)
+* (optional) Zalando's [tokens library](https://github.com/zalando/tokens) >= 0.10.0
+    * Please note that [tokens-spring-boot-starter](https://github.com/zalando-stups/spring-boot-zalando-stups-tokens) 0.10.0 comes with tokens 0.9.9, which is not enough. You can manually add tokens 0.10.0 with that starter, though.
 
 
 ## Usage

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.zalando.stups</groupId>
             <artifactId>tokens</artifactId>
-            <version>0.11.0-beta-2</version>
+            <version>0.10.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
We documented depending on 0.10.0, but were actually referring to 0.11.0-beta-2 in
our pom.xml.
Also some related README updates clearing up some confusion related to #70.