### PR TITLE
Remove @ComponentScan, @Component, @Autowired

### DIFF
--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/EventTransmissionScheduler.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/EventTransmissionScheduler.java
@@ -1,17 +1,13 @@
 package org.zalando.nakadiproducer;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
 import org.zalando.nakadiproducer.transmission.impl.EventTransmitter;
 
-@Component
 public class EventTransmissionScheduler {
     private final EventTransmitter eventTransmitter;
     private final boolean scheduledTransmissionEnabled;
 
-    @Autowired
     public EventTransmissionScheduler(EventTransmitter eventTransmitter, @Value("${nakadi-producer.scheduled-transmission-enabled:true}") boolean scheduledTransmissionEnabled) {
         this.eventTransmitter = eventTransmitter;
         this.scheduledTransmissionEnabled = scheduledTransmissionEnabled;

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -19,7 +19,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -47,7 +46,6 @@ import org.zalando.tracer.Tracer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
-@ComponentScan
 @AutoConfigureAfter(name="org.zalando.tracer.spring.TracerAutoConfiguration")
 public class NakadiProducerAutoConfiguration {
 
@@ -180,6 +178,12 @@ public class NakadiProducerAutoConfiguration {
     @Bean
     public EventTransmitter eventTransmitter(EventTransmissionService eventTransmissionService) {
         return new EventTransmitter(eventTransmissionService);
+    }
+
+    @Bean
+    public EventTransmissionScheduler eventTransmissionScheduler(EventTransmitter eventTransmitter,
+            @Value("${nakadi-producer.scheduled-transmission-enabled:true}") boolean scheduledTransmissionEnabled) {
+        return new EventTransmissionScheduler(eventTransmitter, scheduledTransmissionEnabled);
     }
 
     @Bean

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryImpl.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryImpl.java
@@ -6,19 +6,15 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class EventLogRepositoryImpl implements EventLogRepository {
     private NamedParameterJdbcTemplate jdbcTemplate;
 
-    @Autowired
     public EventLogRepositoryImpl(NamedParameterJdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/FlywayDataSourceIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/FlywayDataSourceIT.java
@@ -12,9 +12,11 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 
+@ContextConfiguration(classes=FlywayDataSourceIT.Config.class)
 public class FlywayDataSourceIT extends BaseMockedExternalCommunicationIT {
     @Autowired
     @NakadiProducerFlywayDataSource

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerationWebEndpointIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerationWebEndpointIT.java
@@ -22,7 +22,7 @@ import org.zalando.nakadiproducer.config.EmbeddedDataSourceConfig;
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = { "management.security.enabled=false", "zalando.team.id:alpha-local-testing", "nakadi-producer.scheduled-transmission-enabled:false" },
-    classes = { TestApplication.class, EmbeddedDataSourceConfig.class }
+    classes = { TestApplication.class, EmbeddedDataSourceConfig.class, SnapshotEventGenerationWebEndpointIT.Config.class }
 )
 public class SnapshotEventGenerationWebEndpointIT {
 

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGeneratorAutoconfigurationIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGeneratorAutoconfigurationIT.java
@@ -11,9 +11,11 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
 import org.zalando.nakadiproducer.BaseMockedExternalCommunicationIT;
 import org.zalando.nakadiproducer.snapshots.impl.SnapshotCreationService;
 
+@ContextConfiguration(classes=SnapshotEventGeneratorAutoconfigurationIT.Config.class)
 public class SnapshotEventGeneratorAutoconfigurationIT extends BaseMockedExternalCommunicationIT {
 
     @Autowired


### PR DESCRIPTION
The main AutoConfiguration class had a `@ComponentScan` annotation, causing the whole `org.zalando.nakadiproducer` package (including all subpackages) to be scanned.
This was used only for two beans.
It had the side effect that during tests (which are in the same package), all kinds of @Configuration classes in other tests were also loaded, thereby confusing what each test is actually testing.

This commit removes the `@ComponentScan` annotation at `NakadiProducerAutoConfiguration`, as well as the now superfluous `@Component` and `@Autowired` annotations in `EventTransmissionScheduler` and `EventLogRepositoryImpl`.
It also fixes three tests to load their own configuration explicitly.

It should not change anything in productive behavior (except if some application reuses our package name, which is a big no-go), just makes our own testing clearer.

This was noted while trying to build some tests for the Autoconfiguration (in preparation for #75).