### PR TITLE
Reuse Fahrschein bean if it already exists (#75).

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This library also uses:
 ### Setup
 
 If you are using maven, include the library in your `pom.xml`:
+
 ```xml
 <dependency>
     <groupId>org.zalando</groupId>
@@ -66,7 +67,10 @@ If you are using maven, include the library in your `pom.xml`:
 </dependency>
 ```
 
+The latest available version is visible in the Maven central badge at the top of this README. 
+
 Use `@EnableNakadiProducer` annotation to activate spring boot starter auto configuration:
+
 ```java
 @SpringBootApplication
 @EnableNakadiProducer
@@ -80,6 +84,23 @@ public class Application {
 The library uses flyway migrations to set up its own database schema `nakadi_events`.
 
 ### Nakadi communication configuration
+
+By default, Nakadi-producer-spring-boot starter uses the Fahrschein library to submit its events. It needs some configuration to know how to do this – we describe three ways here (basically in order of ease of use):
+
+* Using existing Fahrschein setup
+* Letting this library set things up
+* Implement Nakadi communication yourself
+
+#### Using existing Fahrschein setup
+
+If you are already using the [Fahrschein library](https://github.com/zalando-nakadi/fahrschein) directly (e.g. for event consumption) and have already a configured `org.zalando.fahrschein.NakadiClient` object, just make sure it is available as a Spring bean. Nakadi-Producer-Spring-Boot-Starter will pick it up and use it directly.
+
+The configurations in the next section are then not needed at all.
+
+#### Letting this library set things up 
+
+If you want Nakadi-Producer-Spring-Boot-Starter to configure the connection to Nakadi, you'll need to set some properties
+(and/or create beans).
 
 You must tell the library, where it can reach your Nakadi instance:
 ```yaml
@@ -115,6 +136,26 @@ nakadi-producer:
 ```
 
 If you do not use the STUPS Tokens library, you can implement token retrieval yourself by defining a Spring bean of type `org.zalando.nakadiproducer.AccessTokenProvider`. The starter will detect it and call it once for each request to retrieve the token. 
+
+#### Implement Nakadi communication yourself
+
+If you don't like Fahrschein, you can implement the communication with Nakadi yourself. Just provide an implementation of the `NakadiPublishingClient` interface as a Spring bean. Nakadi-producer-spring-boot-starter will just use that bean. (This is used in the [test support](#test-support) described below.)
+
+You can then also exclude the Fahrschein dependency: 
+
+```xml
+<dependency>
+    <groupId>org.zalando</groupId>
+    <artifactId>nakadi-producer-spring-boot-starter</artifactId>
+    <version>${nakadi-producer.version}</version>
+    <exclusions>
+        <exclusion>
+            <groupId>org.zalando</groupId>
+            <artifactId>fahrschein</artifactId>
+        <exclusion>
+    </exclusions>
+</dependency>
+```
 
 ### Creating events
 

--- a/README.md
+++ b/README.md
@@ -85,17 +85,16 @@ The library uses flyway migrations to set up its own database schema `nakadi_eve
 
 ### Nakadi communication configuration
 
-By default, Nakadi-producer-spring-boot starter uses the Fahrschein library to submit its events. It needs some configuration to know how to do this – we describe three ways here (basically in order of ease of use):
+By default, Nakadi-producer-spring-boot starter uses the Fahrschein library to submit its events. It needs some configuration to know how to do this – we support two ways:
 
 * Using existing Fahrschein setup
 * Letting this library set things up
-* Implement Nakadi communication yourself
 
 #### Using existing Fahrschein setup
 
 If you are already using the [Fahrschein library](https://github.com/zalando-nakadi/fahrschein) directly (e.g. for event consumption) and have already a configured `org.zalando.fahrschein.NakadiClient` object, just make sure it is available as a Spring bean. Nakadi-Producer-Spring-Boot-Starter will pick it up and use it directly.
 
-The configurations in the next section are then not needed at all.
+The configuration in the next section is then not needed at all.
 
 #### Letting this library set things up 
 
@@ -137,25 +136,6 @@ nakadi-producer:
 
 If you do not use the STUPS Tokens library, you can implement token retrieval yourself by defining a Spring bean of type `org.zalando.nakadiproducer.AccessTokenProvider`. The starter will detect it and call it once for each request to retrieve the token. 
 
-#### Implement Nakadi communication yourself
-
-If you don't like Fahrschein, you can implement the communication with Nakadi yourself. Just provide an implementation of the `NakadiPublishingClient` interface as a Spring bean. Nakadi-producer-spring-boot-starter will just use that bean. (This is used in the [test support](#test-support) described below.)
-
-You can then also exclude the Fahrschein dependency: 
-
-```xml
-<dependency>
-    <groupId>org.zalando</groupId>
-    <artifactId>nakadi-producer-spring-boot-starter</artifactId>
-    <version>${nakadi-producer.version}</version>
-    <exclusions>
-        <exclusion>
-            <groupId>org.zalando</groupId>
-            <artifactId>fahrschein</artifactId>
-        <exclusion>
-    </exclusions>
-</dependency>
-```
 
 ### Creating events
 

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -49,10 +49,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @AutoConfigureAfter(name="org.zalando.tracer.spring.TracerAutoConfiguration")
 public class NakadiProducerAutoConfiguration {
 
-    @ConditionalOnMissingBean(NakadiPublishingClient.class)
+    @ConditionalOnMissingBean({NakadiPublishingClient.class, NakadiClient.class})
     @Configuration
-    @Import(FahrscheinNakadiClientConfiguration.StupsTokenConfiguration.class)
-    static class FahrscheinNakadiClientConfiguration {
+    @Import(FahrscheinWithTokensNakadiClientConfiguration.StupsTokenConfiguration.class)
+    static class FahrscheinWithTokensNakadiClientConfiguration {
 
         @Bean
         public NakadiPublishingClient nakadiProducerPublishingClient(AccessTokenProvider accessTokenProvider,
@@ -72,6 +72,17 @@ public class NakadiProducerAutoConfiguration {
                     @Value("${nakadi-producer.access-token-scopes:uid}") String[] accessTokenScopes) {
                 return new StupsTokenComponent(accessTokenUri, Arrays.asList(accessTokenScopes));
             }
+        }
+    }
+
+    @ConditionalOnMissingBean(NakadiPublishingClient.class)
+    @ConditionalOnBean(NakadiClient.class)
+    @Configuration
+    static class ExistingFahrscheinNakadiClientConfiguration {
+
+        @Bean
+        public NakadiPublishingClient nakadiProducerPublishingClient(NakadiClient fahrscheinNakadiClient) {
+            return new FahrscheinNakadiPublishingClient(fahrscheinNakadiClient);
         }
     }
 


### PR DESCRIPTION
This provides a way of avoiding a lot of duplicated configuration, if you are both sending and consuming events. (Fixes #75.)

~~Also document how to not use Fahrschein at all.~~