### PR TITLE
Release 20.0.0

### DIFF
--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.0.0-SNAPSHOT</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-starter-spring-boot-2-test/pom.xml
+++ b/nakadi-producer-starter-spring-boot-2-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.0.0-SNAPSHOT</version>
+        <version>20.0.0</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.0.0-SNAPSHOT</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>20.0.0-SNAPSHOT</version>
+    <version>20.0.0</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 


### PR DESCRIPTION
Proposed Release notes (feel free to change and adapt):

## 20.0.0: Spring Boot 2 Support

We now support Spring Boot 2. We will continue to release Spring Boot 1 based versions, too. Their release numbers will be <= 19.x.x (most recent one at the time of this release is 4.2.0).


**Migrating from 4.x to 20.0.0**
- versions >= 20.x will only work with Spring Boot 2
- the Actuator endpoint will be mapped to a different path in Spring Boot 2. Please check [our docs](https://github.com/zalando-nakadi/nakadi-producer-spring-boot-starter/blob/master/README.md) and the [Spring Boot docs](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html#production-ready-endpoints-custom-mapping) to find the exact path (typically `/actuator/snapshot-event-creation`). Authentication of management endpoints has also been changed a lot by Spring Boot 2, so you may have a look at [their docs for this](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html#production-ready-endpoints-security), too.
- The filter specifier can now be given either as a request parameter or as request body. If you specify it as a request body, the format has changed: `{"filter":"myFilter"}`
- You now have to explicitly expose our Actuator endpoints:

    `management.endpoints.web.exposure.include=snapshot-event-creation,your-other-endpoints,...`

- If you used the `NakadiProducerFlywayCallback` annotation before, you'll now have to implement an interface with the same name (instead of implementing `FlywayCallback`) . It's basically just a copy of Flyway's `FlywayCallback` interface, so there shouldn't be too much to change here.
- The `SnapshotEventProvider` interface, which was deprecated in 4.1.0, is now gone. Use `SnapshotEventGenerator` instead.