### PR TITLE
Use META-INF/spring.factories to trigger the auto configuration instead of @EnableNakadiProducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,18 +70,6 @@ If you are using Maven, include the library in your `pom.xml`:
 
 The latest available version is visible in the Maven central badge at the top of this README. 
 
-Use `@EnableNakadiProducer` annotation to activate spring boot starter auto configuration:
-
-```java
-@SpringBootApplication
-@EnableNakadiProducer
-public class Application {
-    public static void main(final String[] args) {
-        SpringApplication.run(TestApplication.class, args);
-    }
-}
-```
-
 The library uses Flyway migrations to set up its own database schema `nakadi_events`.
 
 ### Nakadi communication configuration

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.0.0</version>
+        <version>20.0.1</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/EnableNakadiProducer.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/EnableNakadiProducer.java
@@ -1,7 +1,5 @@
 package org.zalando.nakadiproducer;
 
-import org.springframework.context.annotation.Import;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,11 +7,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotate your Spring Boot Configuration with this annotation to trigger the Nakadi Producer autoconfiguration.
+ * @deprecated This annotation has no effect anymore and will be removed in the next major release
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Import(NakadiProducerAutoConfiguration.class)
 @Documented
+@Deprecated
 public @interface EnableNakadiProducer {
 }

--- a/nakadi-producer-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/nakadi-producer-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.zalando.nakadiproducer.NakadiProducerAutoConfiguration

--- a/nakadi-producer-starter-spring-boot-2-test/pom.xml
+++ b/nakadi-producer-starter-spring-boot-2-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.0.0</version>
+        <version>20.0.1</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer-starter-spring-boot-2-test/src/test/java/org/zalando/nakadiproducer/tests/ApplicationIT.java
+++ b/nakadi-producer-starter-spring-boot-2-test/src/test/java/org/zalando/nakadiproducer/tests/ApplicationIT.java
@@ -15,7 +15,10 @@ import static io.restassured.RestAssured.given;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-        classes = Application.class,
+        // This line looks like that by intention: We want to test that the MockNakadiPublishingClient will be picked up
+        // by our starter *even if* it has been defined *after* the application itself. This has been a problem until
+        // this commit.
+        classes = { Application.class, MockNakadiConfig.class },
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 public class ApplicationIT {

--- a/nakadi-producer-starter-spring-boot-2-test/src/test/java/org/zalando/nakadiproducer/tests/MockNakadiConfig.java
+++ b/nakadi-producer-starter-spring-boot-2-test/src/test/java/org/zalando/nakadiproducer/tests/MockNakadiConfig.java
@@ -1,0 +1,14 @@
+package org.zalando.nakadiproducer.tests;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.zalando.nakadiproducer.transmission.MockNakadiPublishingClient;
+import org.zalando.nakadiproducer.transmission.NakadiPublishingClient;
+
+@Configuration
+public class MockNakadiConfig {
+    @Bean
+    public NakadiPublishingClient mockNakadiPublishingClient() {
+        return new MockNakadiPublishingClient();
+    }
+}

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.0.0</version>
+        <version>20.0.1</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>20.0.0</version>
+    <version>20.0.1</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 


### PR DESCRIPTION
Use META-INF/spring.factories to trigger the auto configuration instead of @EnableNakadiProducer

The later had problems with the initialization order in integration tests, as the starters spring configuration has been processed *after* the applications and the tests one.