### PR TITLE
Fix Jackson vulnerability

### DIFF
--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -33,12 +33,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.8</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>org.zalando</groupId>
@@ -70,13 +68,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.8.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -105,7 +101,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -118,7 +113,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>


### PR DESCRIPTION
This was triggered by an alert from Github:
https://github.com/zalando-nakadi/nakadi-producer-spring-boot-starter/network/alert/nakadi-producer/pom.xml/com.fasterxml.jackson.core:jackson-databind/open

(As I'm not sure how useful this URL will be after I resolve the alert, here the gist of
 its content + my interpretation.)

com.fasterxml.jackson.core:jackson-databind was at version 2.8.8, which is affected
by a bunch of remote code execution vulnerabilities:

- CVE-2017-17485
- CVE-2018-7489
- CVE-2017-7525

Versions from 2.8.11 or higher are not affected.
As the dependency version suggested by our parent pom (spring-boot-starter-parent)
is 2.9.6, we can just remove the version number here.

(I don't think the use of Jackson in this library is vulnerable, as
 we are not parsing, only creating JSON, but it is better to not carry
 broken dependency versions into any application.)

While doing this, I also removed some other version numbers in our pom.xml
which have the same or newer versions in the parent.