### PR TITLE
remove duplicated embedded database in our example app

### DIFF
--- a/nakadi-producer-starter-spring-boot-2-test/src/main/java/org/zalando/nakadiproducer/tests/Application.java
+++ b/nakadi-producer-starter-spring-boot-2-test/src/main/java/org/zalando/nakadiproducer/tests/Application.java
@@ -26,8 +26,8 @@ public class Application {
 
     @Bean
     @Primary
-    public DataSource dataSource() throws IOException {
-        return embeddedPostgres().getPostgresDatabase();
+    public DataSource dataSource(EmbeddedPostgres postgres) throws IOException {
+        return postgres.getPostgresDatabase();
     }
 
     @Bean
@@ -39,9 +39,9 @@ public class Application {
     public SnapshotEventGenerator snapshotEventGenerator() {
         return new SimpleSnapshotEventGenerator("eventtype", (withIdGreaterThan, filter) -> {
             if (withIdGreaterThan == null) {
-                return Collections.singletonList(new Snapshot("1", "foo", (Object) filter));
+                return Collections.singletonList(new Snapshot("1", "foo", filter));
             } else if (withIdGreaterThan.equals("1")) {
-                return Collections.singletonList(new Snapshot("2", "foo", (Object) filter));
+                return Collections.singletonList(new Snapshot("2", "foo", filter));
             } else {
                 return new ArrayList<>();
             }


### PR DESCRIPTION
Previously, in the tests we had each two embedded postgres instances started up,
one as the `embeddedPostgres` bean and one as part of the `dataSource` bean.
(This was visible in the log output, but seemed to not have any other side effects,
 apart from maybe making things slower.)

In `@Configuration` classes calling a different bean class to create your bean will
be caught by a proxy and give the existing bean, but our application main class is
not a `@Configuration` class. Instead, we can use a method parameter to inject the
bean created by the other method.

My IDE also removed a superfluous cast in the same class, not sure why it was there.