### PR TITLE
release 20.1.0

### DIFF
--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.0.1</version>
+        <version>20.1.0</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-starter-spring-boot-2-test/pom.xml
+++ b/nakadi-producer-starter-spring-boot-2-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.0.1</version>
+        <version>20.1.0</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.0.1</version>
+        <version>20.1.0</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>20.0.1</version>
+    <version>20.1.0</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 


### PR DESCRIPTION
Bumping version numbers.

This release contains #110 (for #48), #103 (dependency version changes).
(Also some changes to the tests in #107 and #108.)