### PR TITLE
WIP: start of opentracing support

### DIFF
--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -57,6 +57,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>0.31.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.zalando.stups</groupId>
             <artifactId>tokens</artifactId>
             <version>0.10.0</version>

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -13,7 +13,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.flyway.FlywayProperties;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -30,6 +29,9 @@ import org.zalando.nakadiproducer.eventlog.impl.EventLogWriterImpl;
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
 import org.zalando.nakadiproducer.flowid.NoopFlowIdComponent;
 import org.zalando.nakadiproducer.flowid.TracerFlowIdComponent;
+import org.zalando.nakadiproducer.opentracing.NoopOpenTracingComponent;
+import org.zalando.nakadiproducer.opentracing.OpenTracingComponent;
+import org.zalando.nakadiproducer.opentracing.TracerOpenTracingComponent;
 import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
 import org.zalando.nakadiproducer.snapshots.impl.SnapshotCreationService;
 import org.zalando.nakadiproducer.snapshots.impl.SnapshotEventCreationEndpoint;
@@ -109,6 +111,31 @@ public class NakadiProducerAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(OpenTracingComponent.class)
+    @ConditionalOnMissingClass("io.opentracing.Tracer")
+    public OpenTracingComponent openTracingComponent() {
+        return new NoopOpenTracingComponent();
+    }
+
+    @ConditionalOnClass(name="io.opentracing.Tracer")
+    @Configuration
+    static class OpenTracingConfiguration {
+        @Autowired(required = false)
+        private io.opentracing.Tracer tracer;
+
+        @SuppressWarnings("SpringJavaAutowiringInspection")
+        @ConditionalOnMissingBean(OpenTracingComponent.class)
+        @Bean
+        public OpenTracingComponent openTracingComponent() {
+            if (tracer == null) {
+                return new NoopOpenTracingComponent();
+            } else {
+                return new TracerOpenTracingComponent(tracer);
+            }
+        }
+    }
+
+    @Bean
     @ConditionalOnMissingBean
     public SnapshotEventCreationEndpoint snapshotEventCreationEndpoint(
             SnapshotCreationService snapshotCreationService) {
@@ -127,8 +154,8 @@ public class NakadiProducerAutoConfiguration {
 
     @Bean
     public EventLogWriter eventLogWriter(EventLogRepository eventLogRepository, ObjectMapper objectMapper,
-            FlowIdComponent flowIdComponent) {
-        return new EventLogWriterImpl(eventLogRepository, objectMapper, flowIdComponent);
+            FlowIdComponent flowIdComponent, OpenTracingComponent openTracingComponent) {
+        return new EventLogWriterImpl(eventLogRepository, objectMapper, flowIdComponent, openTracingComponent);
     }
 
     @Bean

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/opentracing/TracerOpenTracingComponent.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/opentracing/TracerOpenTracingComponent.java
@@ -1,0 +1,49 @@
+package org.zalando.nakadiproducer.opentracing;
+
+import io.opentracing.Scope;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapInjectAdapter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TracerOpenTracingComponent implements OpenTracingComponent {
+
+    private class SpanAndScopeImpl implements SpanAndScope {
+
+        private Scope scope;
+
+        public SpanAndScopeImpl(Scope scope) {
+            this.scope = scope;
+        }
+
+        @Override
+        public void close() {
+            scope.close();
+        }
+
+        @Override
+        public Map<String, String> exportSpanContext() {
+            Map<String, String> map = new HashMap<>();
+            SpanContext context = scope.span().context();
+            tracer.inject(context, Format.Builtin.TEXT_MAP, new TextMapInjectAdapter(map));
+            return map;
+        }
+    }
+
+    private Tracer tracer;
+
+    public TracerOpenTracingComponent(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public SpanAndScope startActiveSpan(String name) {
+        return new SpanAndScopeImpl(tracer.buildSpan(name).startActive(true));
+    }
+
+
+
+}

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLog.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLog.java
@@ -25,5 +25,6 @@ public class EventLog {
     private Instant lastModified;
     private String lockedBy;
     private Instant lockedUntil;
+    private String spanContext;
 
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
@@ -6,72 +6,107 @@ import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.SNAPSH
 import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.UPDATE;
 
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
+import org.zalando.nakadiproducer.opentracing.OpenTracingComponent;
+import org.zalando.nakadiproducer.opentracing.OpenTracingComponent.SpanAndScope;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
 
 import javax.transaction.Transactional;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class EventLogWriterImpl implements EventLogWriter {
 
     private final EventLogRepository eventLogRepository;
 
     private final ObjectMapper objectMapper;
     private final FlowIdComponent flowIdComponent;
+    private final OpenTracingComponent openTracingComponent;
 
-    public EventLogWriterImpl(EventLogRepository eventLogRepository, ObjectMapper objectMapper, FlowIdComponent flowIdComponent) {
+    public EventLogWriterImpl(EventLogRepository eventLogRepository, ObjectMapper objectMapper, FlowIdComponent flowIdComponent, OpenTracingComponent openTracingComponent) {
         this.eventLogRepository = eventLogRepository;
         this.objectMapper = objectMapper;
         this.flowIdComponent = flowIdComponent;
+        this.openTracingComponent = openTracingComponent;
     }
 
     @Override
     @Transactional
     public void fireCreateEvent(final String eventType, final String dataType, final Object data) {
-        final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(CREATE.toString(), dataType, data));
-        eventLogRepository.persist(eventLog);
+        try (SpanAndScope span = openTracingComponent.startActiveSpan("fire_create_event")) {
+            final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(CREATE.toString(), dataType, data), span);
+            eventLogRepository.persist(eventLog);
+        }
     }
 
     @Override
     @Transactional
     public void fireUpdateEvent(final String eventType, final String dataType, final Object data) {
-        final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(UPDATE.toString(), dataType, data));
-        eventLogRepository.persist(eventLog);
+        try (SpanAndScope span = openTracingComponent.startActiveSpan("fire_update_event")) {
+            final EventLog eventLog = createEventLog(eventType,
+                    new DataChangeEventEnvelope(UPDATE.toString(), dataType, data), span);
+            eventLogRepository.persist(eventLog);
+        }
     }
 
     @Override
     @Transactional
     public void fireDeleteEvent(final String eventType, final String dataType, final Object data) {
-        final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(DELETE.toString(), dataType, data));
-        eventLogRepository.persist(eventLog);
+        try (SpanAndScope span = openTracingComponent.startActiveSpan("fire_delete_event")) {
+            final EventLog eventLog = createEventLog(eventType,
+                    new DataChangeEventEnvelope(DELETE.toString(), dataType, data), span);
+            eventLogRepository.persist(eventLog);
+        }
     }
 
     @Override
     @Transactional
     public void fireSnapshotEvent(final String eventType, final String dataType, final Object data) {
-        final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(SNAPSHOT.toString(), dataType, data));
-        eventLogRepository.persist(eventLog);
+        try (SpanAndScope span = openTracingComponent.startActiveSpan("fire_snapshot_event")) {
+            final EventLog eventLog = createEventLog(eventType,
+                    new DataChangeEventEnvelope(SNAPSHOT.toString(), dataType, data), span);
+            eventLogRepository.persist(eventLog);
+        }
     }
 
     @Override
     @Transactional
     public void fireBusinessEvent(final String eventType, Object payload) {
-        final EventLog eventLog = createEventLog(eventType, payload);
-        eventLogRepository.persist(eventLog);
+        try (SpanAndScope span = openTracingComponent.startActiveSpan("fire_business_event")) {
+            final EventLog eventLog = createEventLog(eventType, payload, span);
+            eventLogRepository.persist(eventLog);
+        }
     }
 
-    private EventLog createEventLog(final String eventType, final Object eventPayload) {
+    private EventLog createEventLog(final String eventType, final Object eventPayload, SpanAndScope span) {
         final EventLog eventLog = new EventLog();
         eventLog.setEventType(eventType);
+
         try {
             eventLog.setEventBodyData(objectMapper.writeValueAsString(eventPayload));
         } catch (final JsonProcessingException e) {
             throw new IllegalStateException("could not map object to json: " + eventPayload.toString(), e);
         }
 
+        eventLog.setSpanContext(serializeSpanContext(span));
         eventLog.setFlowId(flowIdComponent.getXFlowIdValue());
         return eventLog;
+    }
+
+    private String serializeSpanContext(SpanAndScope span) {
+        Map<String, String> context = span.exportSpanContext();
+        String contextString;
+        try {
+            contextString = objectMapper.writeValueAsString(context);
+        } catch (JsonProcessingException e) {
+            log.error("Could not serialize span context {}", context);
+            contextString = null;
+        }
+        return contextString;
     }
 
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/opentracing/NoopOpenTracingComponent.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/opentracing/NoopOpenTracingComponent.java
@@ -1,0 +1,26 @@
+package org.zalando.nakadiproducer.opentracing;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class NoopOpenTracingComponent implements OpenTracingComponent {
+
+    private static final SpanAndScope NOOP_SPAN_SCOPE = new SpanAndScope() {
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public Map<String, String> exportSpanContext() {
+            return Collections.emptyMap();
+        }
+    };
+
+    @Override
+    public SpanAndScope startActiveSpan(String name) {
+        return NOOP_SPAN_SCOPE;
+    }
+
+
+}

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/opentracing/OpenTracingComponent.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/opentracing/OpenTracingComponent.java
@@ -1,0 +1,16 @@
+package org.zalando.nakadiproducer.opentracing;
+
+import java.io.Closeable;
+import java.util.Map;
+
+/**
+ * This interface provides an abstraction layer to an OpenTracing implementation (or a noop mock thereof).
+ */
+public interface OpenTracingComponent {
+    interface SpanAndScope extends Closeable {
+        @Override
+        void close();
+        public Map<String, String> exportSpanContext();
+    }
+    public SpanAndScope startActiveSpan(String name);
+}

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionService.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionService.java
@@ -15,11 +15,7 @@ import javax.transaction.Transactional;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -131,6 +127,12 @@ public class EventTransmissionService {
         metadata.setEid(convertToUUID(event.getId()));
         metadata.setOccuredAt(event.getCreated());
         metadata.setFlowId(event.getFlowId());
+        if (event.getSpanContext() != null) {
+            Map<String, String> spanContext = objectMapper.readValue(event.getSpanContext(),
+                    new TypeReference<LinkedHashMap<String, String>>() {});
+            metadata.setSpanContext(spanContext);
+        }
+
         nakadiEvent.setMetadata(metadata);
 
         LinkedHashMap<String, Object> payloadDTO = objectMapper.readValue(event.getEventBodyData(), new TypeReference<LinkedHashMap<String, Object>>() { });

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/NakadiMetadata.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/NakadiMetadata.java
@@ -3,6 +3,7 @@ package org.zalando.nakadiproducer.transmission.impl;
 import lombok.Data;
 
 import java.time.Instant;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -19,5 +20,8 @@ public class NakadiMetadata {
 
     @JsonProperty("flow_id")
     private String flowId;
+
+    @JsonProperty("span_ctx")
+    private Map<String, String> spanContext;
 
 }

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.zalando.nakadiproducer.util.Fixture.PUBLISHER_EVENT_TYPE;
 
 import org.junit.Before;
@@ -15,6 +16,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
+import org.zalando.nakadiproducer.opentracing.OpenTracingComponent;
 import org.zalando.nakadiproducer.util.Fixture;
 import org.zalando.nakadiproducer.util.MockPayload;
 
@@ -28,6 +30,11 @@ public class EventLogWriterTest {
 
     @Mock
     private FlowIdComponent flowIdComponent;
+
+    @Mock
+    private OpenTracingComponent openTracingComponent;
+    @Mock
+    private OpenTracingComponent.SpanAndScope spanAndScope;
 
     @Captor
     private ArgumentCaptor<EventLog> eventLogCapture;
@@ -55,8 +62,9 @@ public class EventLogWriterTest {
                 Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
 
         when(flowIdComponent.getXFlowIdValue()).thenReturn(TRACE_ID);
+        when(openTracingComponent.startActiveSpan(anyString())).thenReturn(spanAndScope);
 
-        eventLogWriter = new EventLogWriterImpl(eventLogRepository, new ObjectMapper(), flowIdComponent);
+        eventLogWriter = new EventLogWriterImpl(eventLogRepository, new ObjectMapper(), flowIdComponent, openTracingComponent);
     }
 
     @Test

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/transmission/impl/EventBatcherTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/transmission/impl/EventBatcherTest.java
@@ -125,7 +125,7 @@ public class EventBatcherTest {
     }
 
     private EventLog eventLogEntry(int id, String type) {
-        return new EventLog(id, type, "body", "flow", now(), now(), "me", now());
+        return new EventLog(id, type, "body", "flow", now(), now(), "me", now(), "{}");
     }
 
     private NakadiEvent nakadiEvent(String eid) {


### PR DESCRIPTION
A first concept of the opentracing support requested in #105.

All existing tests are currently running, but I didn't test the new functionality at all, and it likely doesn't work yet.

* We introduce an abstraction layer around the opentracing tracer, as we don't want to add a hard dependency (and need only three methods).
* Then the event log writer creates spans (which hopefully get their calling spans as parents), extracts the span context from them and stores it together with the rest of the event data into the database.
* The event transmitter then puts it into the event metadata which is sent to Nakadi.

TODO:
- [ ] write actual tests for this – both with no available tracer and a tracer as spring bean
- [ ] expand the database schema (Flyway migration)
- [ ] add some documentation