### PR TITLE
fix my user name in codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @bgehrels @pebermann
+# The two maintainers are code owners for everything.
+* @bgehrels @epaul


### PR DESCRIPTION
The codeowners file used my username from our internal systems, not my github.com one, and thus didn't work.

Not sure how that happened, and was not noticed until now.