### PR TITLE
Backport features from v20

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bgehrels @pebermann

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @bgehrels @pebermann
+# The two maintainers are code owners for everything.
+* @bgehrels @epaul

--- a/README.md
+++ b/README.md
@@ -277,21 +277,6 @@ You may also define a spring bean of type `FlywayCallback` and annotate it with 
 interface provide several hook into the schema management lifecycle that may, for example, be used to
  `SET ROLE migrator` before and `RESET ROLE` after each migration. 
 
-### Customizing event locks 
-
-* **lock-duration**: The selected events are locked before transmission. If the transmission fails the events stay locked
-until the lock expires (default: 600 seconds).  
-
-* **lock-duration-buffer**: Since clocks never work exactly synchronous and sending events also takes some time, a safety
-buffer is included. During the last x seconds before the expiration of the lock the events are not considered for 
-transmission (default: 60 seconds).
-
-```yaml
-nakadi-producer:
-  lock-duration: 600 
-  lock-duration-buffer: 60
-``` 
-
 ### Test support
 
 This library provides a mock implementation of its Nakadi client that can be used in integration testing:
@@ -331,6 +316,21 @@ public class MyIT {
 The example above uses `com.jayway.jsonpath:json-path:jar:2.2.0` to parse and test the json results.
 
 Note that you should disable the scheduled event transmission for the test (e.g. by setting `nakadi-producer.scheduled-transmission-enabled:false`), as that might interfere with the manual transmission and the clearing in the test setup, leading to events from one test showing up in the next test, depending on timing issues.
+
+### Customizing event locks
+
+* **lock-duration**: The selected events are locked before transmission. If the transmission fails the events stay locked
+until the lock expires. The default is currently 600 seconds but might change in future releases.  
+
+* **lock-duration-buffer**: Since clocks never work exactly synchronous and sending events also takes some time, a safety
+buffer is included. During the last x seconds before the expiration of the lock the events are not considered for 
+transmission. The default is currently 60 seconds but might change in future releases.
+
+```yaml
+nakadi-producer:
+  lock-duration: 600 
+  lock-duration-buffer: 60
+``` 
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,21 @@ You may also define a spring bean of type `FlywayCallback` and annotate it with 
 interface provide several hook into the schema management lifecycle that may, for example, be used to
  `SET ROLE migrator` before and `RESET ROLE` after each migration. 
 
+### Customizing event locks 
+
+* **lock-duration**: The selected events are locked before transmission. If the transmission fails the events stay locked
+until the lock expires (default: 600 seconds).  
+
+* **lock-duration-buffer**: Since clocks never work exactly synchronous and sending events also takes some time, a safety
+buffer is included. During the last x seconds before the expiration of the lock the events are not considered for 
+transmission (default: 60 seconds).
+
+```yaml
+nakadi-producer:
+  lock-duration: 600 
+  lock-duration-buffer: 60
+``` 
+
 ### Test support
 
 This library provides a mock implementation of its Nakadi client that can be used in integration testing:

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>4.3.1</version>
+        <version>4.4.0</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>
@@ -22,7 +22,6 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.version>1.8</java.version>
-        <zalando-swagger-codegen-maven-plugin.version>0.4.24</zalando-swagger-codegen-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -53,13 +52,13 @@
         <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>tracer-core</artifactId>
-            <version>0.11.2</version>
+            <version>0.17.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.zalando.stups</groupId>
             <artifactId>tokens</artifactId>
-            <version>0.10.0</version>
+            <version>0.12.2</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -98,9 +97,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- needed for the optional spring actuator http endpoints -->
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <scope>test</scope>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 
@@ -124,7 +124,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -137,7 +136,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
@@ -153,7 +151,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -167,7 +165,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -116,8 +116,8 @@ public class NakadiProducerAutoConfiguration {
         @Bean
         @ConditionalOnMissingBean
         public SnapshotEventCreationEndpoint snapshotEventCreationEndpoint(
-                SnapshotCreationService snapshotCreationService) {
-            return new SnapshotEventCreationEndpoint(snapshotCreationService);
+                SnapshotCreationService snapshotCreationService, FlowIdComponent flowIdComponent) {
+            return new SnapshotEventCreationEndpoint(snapshotCreationService, flowIdComponent);
         }
 
         @Bean

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -197,11 +197,16 @@ public class NakadiProducerAutoConfiguration {
         return new EventTransmissionScheduler(eventTransmitter, scheduledTransmissionEnabled);
     }
 
-    @Bean
-    public EventTransmissionService eventTransmissionService(EventLogRepository eventLogRepository,
-            NakadiPublishingClient nakadiPublishingClient, ObjectMapper objectMapper) {
-        return new EventTransmissionService(eventLogRepository, nakadiPublishingClient, objectMapper);
-    }
+  @Bean
+  public EventTransmissionService eventTransmissionService(
+      EventLogRepository eventLogRepository,
+      NakadiPublishingClient nakadiPublishingClient,
+      ObjectMapper objectMapper,
+      @Value("${nakadi-producer.lock-duration:600}") int lockDuration,
+      @Value("${nakadi-producer.lock-duration-buffer:60}") int lockDurationBuffer) {
+    return new EventTransmissionService(
+        eventLogRepository, nakadiPublishingClient, objectMapper, lockDuration, lockDurationBuffer);
+  }
 
     @Bean
     public FlywayMigrator flywayMigrator() {

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/flowid/NoopFlowIdComponent.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/flowid/NoopFlowIdComponent.java
@@ -7,7 +7,10 @@ public class NoopFlowIdComponent implements FlowIdComponent {
 
     @Override
     public String getXFlowIdValue() {
-        log.debug("No bean of class FlowIdComponent was found. Returning null.");
         return null;
+    }
+
+    @Override
+    public void startTraceIfNoneExists() {
     }
 }

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponent.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponent.java
@@ -50,7 +50,7 @@ public class TracerFlowIdComponent implements FlowIdComponent {
                         "Please check your tracer configuration: {}", X_FLOW_ID, e.getMessage());
             }
         } else {
-            log.warn("No bean of class Tracer was found. Returning null.");
+            log.warn("No bean of class Tracer was found.");
         }
     }
 }

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponent.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponent.java
@@ -43,11 +43,8 @@ public class TracerFlowIdComponent implements FlowIdComponent {
         if (tracer != null) {
             try {
                 tracer.get(X_FLOW_ID).getValue();
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException|IllegalStateException e) {
                 tracer.start();
-            } catch (IllegalStateException e) {
-                log.warn("Unexpected Error while checking for an existing Trace Id {}. " +
-                        "Please check your tracer configuration: {}", X_FLOW_ID, e.getMessage());
             }
         } else {
             log.warn("No bean of class Tracer was found.");

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponent.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponent.java
@@ -37,4 +37,20 @@ public class TracerFlowIdComponent implements FlowIdComponent {
         }
         return null;
     }
+
+    @Override
+    public void startTraceIfNoneExists() {
+        if (tracer != null) {
+            try {
+                tracer.get(X_FLOW_ID).getValue();
+            } catch (IllegalArgumentException e) {
+                tracer.start();
+            } catch (IllegalStateException e) {
+                log.warn("Unexpected Error while checking for an existing Trace Id {}. " +
+                        "Please check your tracer configuration: {}", X_FLOW_ID, e.getMessage());
+            }
+        } else {
+            log.warn("No bean of class Tracer was found. Returning null.");
+        }
+    }
 }

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponent.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponent.java
@@ -43,7 +43,11 @@ public class TracerFlowIdComponent implements FlowIdComponent {
         if (tracer != null) {
             try {
                 tracer.get(X_FLOW_ID).getValue();
-            } catch (IllegalArgumentException|IllegalStateException e) {
+            } catch (IllegalArgumentException e) {
+                log.warn("No trace was configured for the name {}. Returning null. " +
+                        "To configure Tracer provide an application property: " +
+                        "tracer.traces.X-Flow-ID=flow-id", X_FLOW_ID);
+            } catch (IllegalStateException e) {
                 tracer.start();
             }
         } else {

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotEventCreationEndpoint.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotEventCreationEndpoint.java
@@ -7,14 +7,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.zalando.nakadiproducer.flowid.FlowIdComponent;
 
 @ConfigurationProperties("endpoints.snapshot-event-creation")
 public class SnapshotEventCreationEndpoint extends AbstractEndpoint<SnapshotEventCreationEndpoint.SnapshotReport> {
     private final SnapshotCreationService snapshotCreationService;
+    private final FlowIdComponent flowIdComponent;
 
-    public SnapshotEventCreationEndpoint(SnapshotCreationService snapshotCreationService) {
+    public SnapshotEventCreationEndpoint(SnapshotCreationService snapshotCreationService, FlowIdComponent flowIdComponent) {
         super("snapshot_event_creation", true, true);
         this.snapshotCreationService = snapshotCreationService;
+        this.flowIdComponent = flowIdComponent;
     }
 
     @Override
@@ -23,6 +26,7 @@ public class SnapshotEventCreationEndpoint extends AbstractEndpoint<SnapshotEven
     }
 
     public void invoke(String eventType, String filter) {
+        flowIdComponent.startTraceIfNoneExists();
         snapshotCreationService.createSnapshotEvents(eventType, filter);
     }
 

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/LockTimeoutIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/LockTimeoutIT.java
@@ -1,0 +1,89 @@
+package org.zalando.nakadiproducer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.zalando.nakadiproducer.eventlog.EventLogWriter;
+import org.zalando.nakadiproducer.eventlog.impl.EventLog;
+import org.zalando.nakadiproducer.transmission.MockNakadiPublishingClient;
+import org.zalando.nakadiproducer.transmission.impl.EventTransmissionService;
+import org.zalando.nakadiproducer.transmission.impl.EventTransmitter;
+import org.zalando.nakadiproducer.util.Fixture;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collection;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+@Transactional
+@SpringBootTest(properties = {
+        "nakadi-producer.scheduled-transmission-enabled:false",
+        "nakadi-producer.lock-duration:300",
+        "nakadi-producer.lock-duration-buffer:30"})
+public class LockTimeoutIT extends BaseMockedExternalCommunicationIT {
+    private static final String MY_EVENT_TYPE = "myEventType";
+
+    @Autowired
+    private EventLogWriter eventLogWriter;
+
+    @Autowired
+    private EventTransmitter eventTransmitter;
+
+    @Autowired
+    private EventTransmissionService eventTransmissionService;
+
+    @Autowired
+    private MockNakadiPublishingClient nakadiClient;
+
+    @Before
+    @After
+    public void clearNakadiEvents() {
+        mockServiceClock(Instant.now());
+        eventTransmitter.sendEvents();
+        nakadiClient.clearSentEvents();
+    }
+
+    @Test
+    public void testLockedUntil() {
+        eventLogWriter.fireBusinessEvent(MY_EVENT_TYPE, Fixture.mockPayload(1, "code123"));
+
+        Instant timeOfInitialLock = Instant.now();
+        mockServiceClock(timeOfInitialLock);
+
+        assertThat(eventTransmissionService.lockSomeEvents().size(), is(1));
+        assertThat(eventTransmissionService.lockSomeEvents(), empty());
+
+        // lock is still valid
+        mockServiceClock(timeOfInitialLock.plus(300 - 5, SECONDS));
+        assertThat(eventTransmissionService.lockSomeEvents(), empty());
+
+        // lock is expired
+        mockServiceClock(timeOfInitialLock.plus(300 + 5, SECONDS));
+        assertThat(eventTransmissionService.lockSomeEvents().size(), is(1));
+    }
+
+    @Test
+    public void testLockNearlyExpired() {
+        eventLogWriter.fireBusinessEvent(MY_EVENT_TYPE, Fixture.mockPayload(1, "code456"));
+        Instant timeOfInitialLock = Instant.now();
+
+        Collection<EventLog> lockedEvent = eventTransmissionService.lockSomeEvents();
+
+        // event will not be sent, because the event-lock is "nearlyExpired"
+        mockServiceClock(timeOfInitialLock.plus(300 - 30 + 5, SECONDS));
+        eventTransmissionService.sendEvents(lockedEvent);
+        assertThat(nakadiClient.getSentEvents(MY_EVENT_TYPE), empty());
+    }
+
+    private void mockServiceClock(Instant ins) {
+        eventTransmissionService.overrideClock(Clock.fixed(ins, ZoneId.systemDefault()));
+    }
+}

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponentTest.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponentTest.java
@@ -29,13 +29,23 @@ public class TracerFlowIdComponentTest {
     }
 
     @Test
-    public void makeSureTraceWillBeStartedIfNoneExists() {
+    public void makeSureTraceWillBeStartedIfNoneHasBeenStartedBefore() {
+        TracerFlowIdComponent flowIdComponent = new TracerFlowIdComponent(tracer);
+        when(tracer.get("X-Flow-ID").getValue()).thenThrow(new IllegalStateException());
+
+        flowIdComponent.startTraceIfNoneExists();
+
+        verify(tracer).start();
+    }
+
+    @Test
+    public void wontFailIfTraceHasNotBeenConfiguredInStartTrace() {
         TracerFlowIdComponent flowIdComponent = new TracerFlowIdComponent(tracer);
         when(tracer.get("X-Flow-ID")).thenThrow(new IllegalArgumentException());
 
         flowIdComponent.startTraceIfNoneExists();
 
-        verify(tracer).start();
+        // then no exception is thrown
     }
 
     @Test

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponentTest.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/flowid/TracerFlowIdComponentTest.java
@@ -1,15 +1,16 @@
 package org.zalando.nakadiproducer.flowid;
 
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.zalando.nakadiproducer.flowid.TracerFlowIdComponent;
 import org.zalando.tracer.Tracer;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -21,10 +22,30 @@ public class TracerFlowIdComponentTest {
     @Test
     public void makeSureItWorks() {
         TracerFlowIdComponent flowIdComponent = new TracerFlowIdComponent(tracer);
-        Mockito.when(tracer.get("X-Flow-ID").getValue()).thenReturn("A_FUNKY_VALUE");
+        when(tracer.get("X-Flow-ID").getValue()).thenReturn("A_FUNKY_VALUE");
 
         assertThat(flowIdComponent.getXFlowIdKey(), Matchers.equalTo("X-Flow-ID"));
         assertThat(flowIdComponent.getXFlowIdValue(), Matchers.equalTo("A_FUNKY_VALUE"));
+    }
+
+    @Test
+    public void makeSureTraceWillBeStartedIfNoneExists() {
+        TracerFlowIdComponent flowIdComponent = new TracerFlowIdComponent(tracer);
+        when(tracer.get("X-Flow-ID")).thenThrow(new IllegalArgumentException());
+
+        flowIdComponent.startTraceIfNoneExists();
+
+        verify(tracer).start();
+    }
+
+    @Test
+    public void makeSureTraceWillNotStartedIfOneExists() {
+        TracerFlowIdComponent flowIdComponent = new TracerFlowIdComponent(tracer);
+        when(tracer.get("X-Flow-ID").getValue()).thenReturn("A_FUNKY_VALUE");
+
+        flowIdComponent.startTraceIfNoneExists();
+
+        verify(tracer, never()).start();
     }
 
 }

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>
@@ -22,7 +22,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.version>1.8</java.version>
-        <zalando-swagger-codegen-maven-plugin.version>0.4.24</zalando-swagger-codegen-maven-plugin.version>
+        <mockito.version>2.27.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <!--  2.8.8 has some vulnerabilities -->
-            <version>2.8.11.2</version>
+            <version>2.8.11.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -43,7 +43,12 @@
         <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>fahrschein</artifactId>
-            <version>0.9.1</version>
+            <version>0.17.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>27.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -57,7 +62,7 @@
         <dependency>
             <groupId>javax.interceptor</groupId>
             <artifactId>javax.interceptor-api</artifactId>
-            <version>1.2</version>
+            <version>1.2.2</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -70,7 +75,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.8.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -104,7 +108,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -117,7 +120,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>4.3.1</version>
+        <version>4.4.0</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/flowid/FlowIdComponent.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/flowid/FlowIdComponent.java
@@ -2,4 +2,6 @@ package org.zalando.nakadiproducer.flowid;
 
 public interface FlowIdComponent {
     String getXFlowIdValue();
+
+    void startTraceIfNoneExists();
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/MockNakadiPublishingClient.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/MockNakadiPublishingClient.java
@@ -1,10 +1,8 @@
 package org.zalando.nakadiproducer.transmission;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -14,10 +12,12 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 public class MockNakadiPublishingClient implements NakadiPublishingClient {
     private final ObjectMapper objectMapper;
-    private final MultiValueMap<String, String> sentEvents = new LinkedMultiValueMap<>();
+    private final Multimap<String, String> sentEvents = ArrayListMultimap.create();
 
     public MockNakadiPublishingClient() {
         this(createDefaultObjectMapper());
@@ -29,12 +29,12 @@ public class MockNakadiPublishingClient implements NakadiPublishingClient {
 
     @Override
     public synchronized void publish(String eventType, List<?> nakadiEvents) throws Exception {
-        nakadiEvents.stream().map(this::transformToJson).forEach(e -> sentEvents.add(eventType, e));
+        nakadiEvents.stream().map(this::transformToJson).forEach(e -> sentEvents.put(eventType, e));
     }
 
     public synchronized List<String> getSentEvents(String eventType) {
         ArrayList<String> events = new ArrayList<>();
-        List<String> sentEvents = this.sentEvents.get(eventType);
+        Collection<String> sentEvents = this.sentEvents.get(eventType);
         if (sentEvents != null) {
             events.addAll(sentEvents);
         }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionService.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionService.java
@@ -36,10 +36,6 @@ public class EventTransmissionService {
 
     private Clock clock = Clock.systemDefaultZone();
 
-    public EventTransmissionService(EventLogRepository eventLogRepository, NakadiPublishingClient nakadiPublishingClient, ObjectMapper objectMapper) {
-        this(eventLogRepository, nakadiPublishingClient, objectMapper, 600, 60);
-    }
-
     public EventTransmissionService(EventLogRepository eventLogRepository, NakadiPublishingClient nakadiPublishingClient, ObjectMapper objectMapper,
     int lockDuration, int lockDurationBuffer) {
         this.eventLogRepository = eventLogRepository;

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionServiceTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionServiceTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.zalando.fahrschein.EventPublishingException;
 import org.zalando.fahrschein.domain.BatchItemResponse;
@@ -53,7 +52,7 @@ public class EventTransmissionServiceTest {
         repo = mock(EventLogRepository.class);
         publishingClient = spy(new MockNakadiPublishingClient());
         mapper = spy(new ObjectMapper());
-        service = new EventTransmissionService(repo, publishingClient, mapper);
+        service = new EventTransmissionService(repo, publishingClient, mapper, 600, 60);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>4.3.1</version>
+    <version>4.4.0</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.3.RELEASE</version>
+        <version>1.5.20.RELEASE</version>
     </parent>
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>4.3.0</version>
+    <version>4.3.1</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>


### PR DESCRIPTION
- Upgraded dependencies to their must current, compatible version (Spring-boot & co, fahrschein, tokens, tracer)
  - Had to fix two things, because Spring changed their jar dependency graph:
  1. We don't depend on Springs internal MultiValueMap anymore but use Guava instead.
  2. Had to explicitly add spring-boot-starter-web, because it has not been implicitly part of actuator anymore
- back ported the automated Trace creation during snapshots (#116)
- back ported the CODEOWNERS file (#91 + #122)
- back ported #120 make lock-timeout configurable
- thought about backporting the performance tests, too, but since [Spring Boot 1 goes End-of-Live 2019-08-01](https://spring.io/blog/2018/07/30/spring-boot-1-x-eol-aug-1st-2019), i don't think we'll have much use for it until then.

- updated the version number in preparation for a new release

