### PR TITLE
#140 Persist multiple events in batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,35 +206,6 @@ For business events, you have just two parameters, the **eventType** and the eve
 You usually should fire those also in the same transaction as you are storing the results of the
 process step the event is reporting.
 
-Example of using `fireCreateEvents`:
-
-```java
-@Service
-public class SomeYourService {
-
-    @Autowired
-    private EventLogWriter eventLogWriter;
-
-    @Autowired
-    private WarehouseRepository repository;
-    
-    @Transactional
-    public void createObjects(Collections<Warehouse> data) {
-        
-        // here we store an object in a database table
-        repository.saveAll(data);
-
-        // then we group the data by dataType
-        Map<String, Collection<Object>> groupedData = Map.of("wholesale:warehouse", data);
-       
-        // and then in the same transaction we save the events about the object creation
-        eventLogWriter.fireCreateEvents("wholesale.warehouse-change-event", groupedData);
-    }
-}
-```
-
-
-
 ### Event snapshots (optional)
 
 A Snapshot event is a special type of data change event (data operation) defined by Nakadi.

--- a/nakadi-producer-loadtest/pom.xml
+++ b/nakadi-producer-loadtest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.3.1</version>
+        <version>20.3.2</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer-loadtest/pom.xml
+++ b/nakadi-producer-loadtest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.3.2</version>
+        <version>20.4.0</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer-loadtest/pom.xml
+++ b/nakadi-producer-loadtest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.4.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.3.1</version>
+        <version>20.3.2</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.3.2</version>
+        <version>20.4.0</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.4.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryIT.java
@@ -38,10 +38,8 @@ public class EventLogRepositoryIT extends BaseMockedExternalCommunicationIT {
 
     private final String WAREHOUSE_EVENT_TYPE = "wholesale.warehouse-change-event";
 
-    private Integer id;
-
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         eventLogRepository.deleteAll();
 
         final EventLog eventLog = EventLog.builder().eventBodyData(WAREHOUSE_EVENT_BODY_DATA)

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryIT.java
@@ -8,6 +8,7 @@ import javax.transaction.Transactional;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.zalando.nakadiproducer.BaseMockedExternalCommunicationIT;
 
 @Transactional
@@ -15,6 +16,9 @@ public class EventLogRepositoryIT extends BaseMockedExternalCommunicationIT {
 
     @Autowired
     private EventLogRepositoryImpl eventLogRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     private static final String WAREHOUSE_EVENT_BODY_DATA =
             ("{'self':'http://WAREHOUSE_DOMAIN',"
@@ -44,11 +48,13 @@ public class EventLogRepositoryIT extends BaseMockedExternalCommunicationIT {
                                                                      .eventType(WAREHOUSE_EVENT_TYPE)
                                                                      .flowId("FLOW_ID").build();
         eventLogRepository.persist(eventLog);
-        id = eventLog.getId();
     }
 
     @Test
     public void findEventRepositoryId() {
+        Integer id = jdbcTemplate.queryForObject(
+            "SELECT id FROM nakadi_events.event_log WHERE flow_id = 'FLOW_ID'",
+            Integer.class);
         final EventLog eventLog = eventLogRepository.findOne(id);
         compareWithPersistedEvent(eventLog);
     }

--- a/nakadi-producer-starter-spring-boot-2-test/pom.xml
+++ b/nakadi-producer-starter-spring-boot-2-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.4.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer-starter-spring-boot-2-test/pom.xml
+++ b/nakadi-producer-starter-spring-boot-2-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.3.1</version>
+        <version>20.3.2</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer-starter-spring-boot-2-test/pom.xml
+++ b/nakadi-producer-starter-spring-boot-2-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.3.2</version>
+        <version>20.4.0</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.4.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.3.1</version>
+        <version>20.3.2</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>20.3.2</version>
+        <version>20.4.0</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadiproducer.eventlog;
 
+import java.util.Collection;
 import javax.transaction.Transactional;
 
 import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
@@ -132,4 +133,19 @@ public interface EventLogWriter {
      */
     @Transactional
     void fireBusinessEvent(String eventType, Object payload);
+
+  /**
+   * Fires business events, see {@link #fireBusinessEvent(String, Object) fireBusinessEvent} for
+   * more details
+   *
+   * @param eventType
+   *            the Nakadi event type of the event. This is roughly equivalent
+   *            to an event channel or topic.
+   *
+   * @param payloads
+   *            some POJOs that can be serialized into JSON (required
+   *            parameter)
+   */
+    @Transactional
+    void fireBusinessEvents(String eventType, Collection<Object> payloads);
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
@@ -62,7 +62,7 @@ public interface EventLogWriter {
    *            the {@code data} field of the Nakadi event.
    */
     @Transactional
-    void fireCreateEvents(String eventType, String dataType, Collection<Object> data);
+    void fireCreateEvents(String eventType, String dataType, Collection<?> data);
 
     /**
      * Fires a data change event about an update of some resource (object).
@@ -103,7 +103,7 @@ public interface EventLogWriter {
    *            the {@code data} field of the Nakadi event.
    */
     @Transactional
-    void fireUpdateEvents(String eventType, String dataType, Collection<Object> data);
+    void fireUpdateEvents(String eventType, String dataType, Collection<?> data);
 
     /**
      * Fires a data change event about the deletion of some resource (object).
@@ -145,7 +145,7 @@ public interface EventLogWriter {
    *            the {@code data} field of the Nakadi event.
    */
     @Transactional
-    void fireDeleteEvents(String eventType, String dataType, Collection<Object> data);
+    void fireDeleteEvents(String eventType, String dataType, Collection<?> data);
 
     /**
      * Fires a data change event with a snapshot of some resource (object).
@@ -198,7 +198,7 @@ public interface EventLogWriter {
    *            the {@code data} field of the Nakadi event.
    */
     @Transactional
-    void fireSnapshotEvents(String eventType, String dataType, Collection<Object> data);
+    void fireSnapshotEvents(String eventType, String dataType, Collection<?> data);
 
     /**
      * Fires a business event, i.e. an event communicating the fact that some

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
@@ -1,7 +1,6 @@
 package org.zalando.nakadiproducer.eventlog;
 
 import java.util.Collection;
-import java.util.Map;
 import javax.transaction.Transactional;
 
 import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
@@ -55,6 +54,7 @@ public interface EventLogWriter {
    * @param dataType
    *            the content of the {@code data_type} field of the Nakadi
    *            event
+   *
    * @param data
    *            some POJOs that can be serialized into JSON (required
    *            parameter). This is meant to be a representation of the
@@ -92,15 +92,18 @@ public interface EventLogWriter {
    *            the Nakadi event type of the event. This is roughly equivalent
    *            to an event channel or topic.
    *
-   * @param dataTypeToData
+   * @param dataType
    *            the content of the {@code data_type} field of the Nakadi
-   *            event mapped to some POJOs that can be serialized into JSON (required
+   *            event
+   *
+   * @param data
+   *            some POJOs that can be serialized into JSON (required
    *            parameter). This is meant to be a representation of the
    *            current state of the resource. It will be used as content of
    *            the {@code data} field of the Nakadi event.
    */
     @Transactional
-    void fireUpdateEvents(String eventType, Map<String, Collection<Object>> dataTypeToData);
+    void fireUpdateEvents(String eventType, String dataType, Collection<Object> data);
 
     /**
      * Fires a data change event about the deletion of some resource (object).
@@ -131,15 +134,18 @@ public interface EventLogWriter {
    *            the Nakadi event type of the event. This is roughly equivalent
    *            to an event channel or topic.
    *
-   * @param dataTypeToData
+   * @param dataType
    *            the content of the {@code data_type} field of the Nakadi
-   *            event mapped to some POJOs that can be serialized into JSON (required
+   *            event
+   *
+   * @param data
+   *            some POJOs that can be serialized into JSON (required
    *            parameter). This is meant to be a representation of the
    *            current state of the resource. It will be used as content of
    *            the {@code data} field of the Nakadi event.
    */
     @Transactional
-    void fireDeleteEvents(String eventType, Map<String, Collection<Object>> dataTypeToData);
+    void fireDeleteEvents(String eventType, String dataType, Collection<Object> data);
 
     /**
      * Fires a data change event with a snapshot of some resource (object).
@@ -181,15 +187,18 @@ public interface EventLogWriter {
    *            the Nakadi event type of the event. This is roughly equivalent
    *            to an event channel or topic.
    *
-   * @param dataTypeToData
+   * @param dataType
    *            the content of the {@code data_type} field of the Nakadi
-   *            event mapped to some POJOs that can be serialized into JSON (required
+   *            event
+   *
+   * @param data
+   *            some POJOs that can be serialized into JSON (required
    *            parameter). This is meant to be a representation of the
    *            current state of the resource. It will be used as content of
    *            the {@code data} field of the Nakadi event.
    */
     @Transactional
-    void fireSnapshotEvents(String eventType, Map<String, Collection<Object>> dataTypeToData);
+    void fireSnapshotEvents(String eventType, String dataType, Collection<Object> data);
 
     /**
      * Fires a business event, i.e. an event communicating the fact that some

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
@@ -1,6 +1,7 @@
 package org.zalando.nakadiproducer.eventlog;
 
 import java.util.Collection;
+import java.util.Map;
 import javax.transaction.Transactional;
 
 import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
@@ -43,6 +44,24 @@ public interface EventLogWriter {
     @Transactional
     void fireCreateEvent(String eventType, String dataType, Object data);
 
+  /**
+   * Fires data change events about the creation of some resources (objects), see
+   * {@link #fireCreateEvent(String, String, Object) fireCreateEvent} for more details.
+   *
+   * @param eventType
+   *            the Nakadi event type of the event. This is roughly equivalent
+   *            to an event channel or topic.
+   *
+   * @param dataTypeToData
+   *            the content of the {@code data_type} field of the Nakadi
+   *            event mapped to some POJOs that can be serialized into JSON (required
+   *            parameter). This is meant to be a representation of the
+   *            current state of the resource. It will be used as content of
+   *            the {@code data} field of the Nakadi event.
+   */
+    @Transactional
+    void fireCreateEvents(String eventType, Map<String, Collection<Object>> dataTypeToData);
+
     /**
      * Fires a data change event about an update of some resource (object).
      *
@@ -62,6 +81,24 @@ public interface EventLogWriter {
      */
     @Transactional
     void fireUpdateEvent(String eventType, String dataType, Object data);
+
+  /**
+   * Fires data change events about the update of some resources (objects), see
+   * {@link #fireUpdateEvent(String, String, Object) fireUpdateEvent} for more details.
+   *
+   * @param eventType
+   *            the Nakadi event type of the event. This is roughly equivalent
+   *            to an event channel or topic.
+   *
+   * @param dataTypeToData
+   *            the content of the {@code data_type} field of the Nakadi
+   *            event mapped to some POJOs that can be serialized into JSON (required
+   *            parameter). This is meant to be a representation of the
+   *            current state of the resource. It will be used as content of
+   *            the {@code data} field of the Nakadi event.
+   */
+    @Transactional
+    void fireUpdateEvents(String eventType, Map<String, Collection<Object>> dataTypeToData);
 
     /**
      * Fires a data change event about the deletion of some resource (object).
@@ -83,6 +120,24 @@ public interface EventLogWriter {
      */
     @Transactional
     void fireDeleteEvent(String eventType, String dataType, Object data);
+
+  /**
+   * Fires data change events about the deletion of some resources (objects), see
+   * {@link #fireDeleteEvent(String, String, Object) fireDeleteEvent} for more details.
+   *
+   * @param eventType
+   *            the Nakadi event type of the event. This is roughly equivalent
+   *            to an event channel or topic.
+   *
+   * @param dataTypeToData
+   *            the content of the {@code data_type} field of the Nakadi
+   *            event mapped to some POJOs that can be serialized into JSON (required
+   *            parameter). This is meant to be a representation of the
+   *            current state of the resource. It will be used as content of
+   *            the {@code data} field of the Nakadi event.
+   */
+    @Transactional
+    void fireDeleteEvents(String eventType, Map<String, Collection<Object>> dataTypeToData);
 
     /**
      * Fires a data change event with a snapshot of some resource (object).
@@ -115,6 +170,24 @@ public interface EventLogWriter {
      */
     @Transactional
     void fireSnapshotEvent(String eventType, String dataType, Object data);
+
+  /**
+   * Fires data change events, see {@link #fireSnapshotEvent(String, String, Object)
+   * fireSnapshotEvent} for more details.
+   *
+   * @param eventType
+   *            the Nakadi event type of the event. This is roughly equivalent
+   *            to an event channel or topic.
+   *
+   * @param dataTypeToData
+   *            the content of the {@code data_type} field of the Nakadi
+   *            event mapped to some POJOs that can be serialized into JSON (required
+   *            parameter). This is meant to be a representation of the
+   *            current state of the resource. It will be used as content of
+   *            the {@code data} field of the Nakadi event.
+   */
+    @Transactional
+    void fireSnapshotEvents(String eventType, Map<String, Collection<Object>> dataTypeToData);
 
     /**
      * Fires a business event, i.e. an event communicating the fact that some

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepository.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepository.java
@@ -13,9 +13,9 @@ public interface EventLogRepository {
     void persist(EventLog eventLog);
 
     default void persist(Collection<EventLog> eventLogs) {
-      for (EventLog eventLog : eventLogs) {
-        persist(eventLog);
-      }
+        for (EventLog eventLog : eventLogs) {
+            persist(eventLog);
+        }
     }
 
     void deleteAll();

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepository.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepository.java
@@ -12,6 +12,8 @@ public interface EventLogRepository {
 
     void persist(EventLog eventLog);
 
+    void persist(Collection<EventLog> eventLogs);
+
     void deleteAll();
 
     EventLog findOne(Integer id);

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepository.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepository.java
@@ -12,7 +12,11 @@ public interface EventLogRepository {
 
     void persist(EventLog eventLog);
 
-    void persist(Collection<EventLog> eventLogs);
+    default void persist(Collection<EventLog> eventLogs) {
+      for (EventLog eventLog : eventLogs) {
+        persist(eventLog);
+      }
+    }
 
     void deleteAll();
 

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
@@ -6,7 +6,6 @@ import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.SNAPSH
 import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.UPDATE;
 
 import java.util.Collection;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
@@ -38,8 +37,8 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
-    public void fireCreateEvents(final String eventType, final Map<String, Collection<Object>> dataTypeToData) {
-      eventLogRepository.persist(createEventLogs(eventType, CREATE, dataTypeToData));
+    public void fireCreateEvents(final String eventType, final String dataType, final Collection<Object> data) {
+      eventLogRepository.persist(createEventLogs(eventType, CREATE, dataType, data));
     }
 
     @Override
@@ -51,8 +50,8 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
-    public void fireUpdateEvents(final String eventType, final Map<String, Collection<Object>> dataTypeToData) {
-      eventLogRepository.persist(createEventLogs(eventType, UPDATE, dataTypeToData));
+    public void fireUpdateEvents(final String eventType, final String dataType, final Collection<Object> data) {
+      eventLogRepository.persist(createEventLogs(eventType, UPDATE, dataType, data));
     }
 
     @Override
@@ -64,8 +63,8 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
-    public void fireDeleteEvents(final String eventType, final Map<String, Collection<Object>> dataTypeToData) {
-      eventLogRepository.persist(createEventLogs(eventType, DELETE, dataTypeToData));
+    public void fireDeleteEvents(final String eventType, final String dataType, final Collection<Object> data) {
+      eventLogRepository.persist(createEventLogs(eventType, DELETE, dataType, data));
     }
 
     @Override
@@ -77,8 +76,8 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
-    public void fireSnapshotEvents(final String eventType, final Map<String, Collection<Object>> dataTypeToData) {
-      eventLogRepository.persist(createEventLogs(eventType, SNAPSHOT, dataTypeToData));
+    public void fireSnapshotEvents(final String eventType, final String dataType, final Collection<Object> data) {
+      eventLogRepository.persist(createEventLogs(eventType, SNAPSHOT, dataType, data));
     }
 
     @Override
@@ -118,15 +117,12 @@ public class EventLogWriterImpl implements EventLogWriter {
   private Collection<EventLog> createEventLogs(
       final String eventType,
       final EventDataOperation eventDataOperation,
-      final Map<String, Collection<Object>> dataTypeToData
+      final String dataType,
+      final Collection<Object> data
   ) {
-    return dataTypeToData.entrySet().stream()
-        .flatMap(entry -> entry.getValue()
-            .stream()
-            .map(data -> createEventLog(
-                eventType,
-                new DataChangeEventEnvelope(eventDataOperation.toString(), entry.getKey(), data)
-            )))
+    return data.stream()
+        .map(payload -> createEventLog(eventType,
+            new DataChangeEventEnvelope(eventDataOperation.toString(), dataType, payload)))
         .collect(Collectors.toList());
   }
 

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
@@ -1,12 +1,13 @@
 package org.zalando.nakadiproducer.eventlog.impl;
 
+import static java.util.stream.Collectors.toList;
 import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.CREATE;
 import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.DELETE;
 import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.SNAPSHOT;
 import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.UPDATE;
 
 import java.util.Collection;
-import java.util.stream.Collectors;
+
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
 
@@ -38,7 +39,7 @@ public class EventLogWriterImpl implements EventLogWriter {
     @Override
     @Transactional
     public void fireCreateEvents(final String eventType, final String dataType, final Collection<?> data) {
-      eventLogRepository.persist(createEventLogs(eventType, CREATE, dataType, data));
+        eventLogRepository.persist(createEventLogs(eventType, CREATE, dataType, data));
     }
 
     @Override
@@ -51,7 +52,7 @@ public class EventLogWriterImpl implements EventLogWriter {
     @Override
     @Transactional
     public void fireUpdateEvents(final String eventType, final String dataType, final Collection<?> data) {
-      eventLogRepository.persist(createEventLogs(eventType, UPDATE, dataType, data));
+        eventLogRepository.persist(createEventLogs(eventType, UPDATE, dataType, data));
     }
 
     @Override
@@ -64,7 +65,7 @@ public class EventLogWriterImpl implements EventLogWriter {
     @Override
     @Transactional
     public void fireDeleteEvents(final String eventType, final String dataType, final Collection<?> data) {
-      eventLogRepository.persist(createEventLogs(eventType, DELETE, dataType, data));
+        eventLogRepository.persist(createEventLogs(eventType, DELETE, dataType, data));
     }
 
     @Override
@@ -77,7 +78,7 @@ public class EventLogWriterImpl implements EventLogWriter {
     @Override
     @Transactional
     public void fireSnapshotEvents(final String eventType, final String dataType, final Collection<?> data) {
-      eventLogRepository.persist(createEventLogs(eventType, SNAPSHOT, dataType, data));
+        eventLogRepository.persist(createEventLogs(eventType, SNAPSHOT, dataType, data));
     }
 
     @Override
@@ -95,10 +96,10 @@ public class EventLogWriterImpl implements EventLogWriter {
     }
 
     private Collection<EventLog> createEventLogs(final String eventType,
-        final Collection<Object> eventPayloads) {
-      return eventPayloads.stream()
-          .map(payload -> createEventLog(eventType, payload))
-          .collect(Collectors.toList());
+                                                 final Collection<Object> eventPayloads) {
+        return eventPayloads.stream()
+                .map(payload -> createEventLog(eventType, payload))
+                .collect(toList());
     }
 
     private EventLog createEventLog(final String eventType, final Object eventPayload) {
@@ -114,16 +115,16 @@ public class EventLogWriterImpl implements EventLogWriter {
         return eventLog;
     }
 
-  private Collection<EventLog> createEventLogs(
-      final String eventType,
-      final EventDataOperation eventDataOperation,
-      final String dataType,
-      final Collection<?> data
-  ) {
-    return data.stream()
-        .map(payload -> createEventLog(eventType,
-            new DataChangeEventEnvelope(eventDataOperation.toString(), dataType, payload)))
-        .collect(Collectors.toList());
-  }
+    private Collection<EventLog> createEventLogs(
+            final String eventType,
+            final EventDataOperation eventDataOperation,
+            final String dataType,
+            final Collection<?> data
+    ) {
+        return data.stream()
+                .map(payload -> createEventLog(eventType,
+                        new DataChangeEventEnvelope(eventDataOperation.toString(), dataType, payload)))
+                .collect(toList());
+    }
 
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
@@ -37,7 +37,7 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
-    public void fireCreateEvents(final String eventType, final String dataType, final Collection<Object> data) {
+    public void fireCreateEvents(final String eventType, final String dataType, final Collection<?> data) {
       eventLogRepository.persist(createEventLogs(eventType, CREATE, dataType, data));
     }
 
@@ -50,7 +50,7 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
-    public void fireUpdateEvents(final String eventType, final String dataType, final Collection<Object> data) {
+    public void fireUpdateEvents(final String eventType, final String dataType, final Collection<?> data) {
       eventLogRepository.persist(createEventLogs(eventType, UPDATE, dataType, data));
     }
 
@@ -63,7 +63,7 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
-    public void fireDeleteEvents(final String eventType, final String dataType, final Collection<Object> data) {
+    public void fireDeleteEvents(final String eventType, final String dataType, final Collection<?> data) {
       eventLogRepository.persist(createEventLogs(eventType, DELETE, dataType, data));
     }
 
@@ -76,7 +76,7 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
-    public void fireSnapshotEvents(final String eventType, final String dataType, final Collection<Object> data) {
+    public void fireSnapshotEvents(final String eventType, final String dataType, final Collection<?> data) {
       eventLogRepository.persist(createEventLogs(eventType, SNAPSHOT, dataType, data));
     }
 
@@ -118,7 +118,7 @@ public class EventLogWriterImpl implements EventLogWriter {
       final String eventType,
       final EventDataOperation eventDataOperation,
       final String dataType,
-      final Collection<Object> data
+      final Collection<?> data
   ) {
     return data.stream()
         .map(payload -> createEventLog(eventType,

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
@@ -6,7 +6,7 @@ import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.SNAPSH
 import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.UPDATE;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
@@ -38,9 +38,21 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
+    public void fireCreateEvents(final String eventType, final Map<String, Collection<Object>> dataTypeToData) {
+      eventLogRepository.persist(createEventLogs(eventType, CREATE, dataTypeToData));
+    }
+
+    @Override
+    @Transactional
     public void fireUpdateEvent(final String eventType, final String dataType, final Object data) {
         final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(UPDATE.toString(), dataType, data));
         eventLogRepository.persist(eventLog);
+    }
+
+    @Override
+    @Transactional
+    public void fireUpdateEvents(final String eventType, final Map<String, Collection<Object>> dataTypeToData) {
+      eventLogRepository.persist(createEventLogs(eventType, UPDATE, dataTypeToData));
     }
 
     @Override
@@ -52,9 +64,21 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
+    public void fireDeleteEvents(final String eventType, final Map<String, Collection<Object>> dataTypeToData) {
+      eventLogRepository.persist(createEventLogs(eventType, DELETE, dataTypeToData));
+    }
+
+    @Override
+    @Transactional
     public void fireSnapshotEvent(final String eventType, final String dataType, final Object data) {
         final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(SNAPSHOT.toString(), dataType, data));
         eventLogRepository.persist(eventLog);
+    }
+
+    @Override
+    @Transactional
+    public void fireSnapshotEvents(final String eventType, final Map<String, Collection<Object>> dataTypeToData) {
+      eventLogRepository.persist(createEventLogs(eventType, SNAPSHOT, dataTypeToData));
     }
 
     @Override
@@ -90,5 +114,20 @@ public class EventLogWriterImpl implements EventLogWriter {
         eventLog.setFlowId(flowIdComponent.getXFlowIdValue());
         return eventLog;
     }
+
+  private Collection<EventLog> createEventLogs(
+      final String eventType,
+      final EventDataOperation eventDataOperation,
+      final Map<String, Collection<Object>> dataTypeToData
+  ) {
+    return dataTypeToData.entrySet().stream()
+        .flatMap(entry -> entry.getValue()
+            .stream()
+            .map(data -> createEventLog(
+                eventType,
+                new DataChangeEventEnvelope(eventDataOperation.toString(), entry.getKey(), data)
+            )))
+        .collect(Collectors.toList());
+  }
 
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
@@ -5,6 +5,9 @@ import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.DELETE
 import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.SNAPSHOT;
 import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.UPDATE;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
 
@@ -59,6 +62,20 @@ public class EventLogWriterImpl implements EventLogWriter {
     public void fireBusinessEvent(final String eventType, Object payload) {
         final EventLog eventLog = createEventLog(eventType, payload);
         eventLogRepository.persist(eventLog);
+    }
+
+    @Override
+    @Transactional
+    public void fireBusinessEvents(final String eventType, final Collection<Object> payload) {
+        final Collection<EventLog> eventLogs = createEventLogs(eventType, payload);
+        eventLogRepository.persist(eventLogs);
+    }
+
+    private Collection<EventLog> createEventLogs(final String eventType,
+        final Collection<Object> eventPayloads) {
+      return eventPayloads.stream()
+          .map(payload -> createEventLog(eventType, payload))
+          .collect(Collectors.toList());
     }
 
     private EventLog createEventLog(final String eventType, final Object eventPayload) {

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
@@ -32,261 +32,264 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @RunWith(MockitoJUnitRunner.class)
 public class EventLogWriterTest {
 
-  @Mock
-  private EventLogRepository eventLogRepository;
+    @Mock
+    private EventLogRepository eventLogRepository;
 
-  @Mock
-  private FlowIdComponent flowIdComponent;
+    @Mock
+    private FlowIdComponent flowIdComponent;
 
-  @Captor
-  private ArgumentCaptor<EventLog> eventLogCapture;
+    @Captor
+    private ArgumentCaptor<EventLog> eventLogCapture;
 
-  @Captor
-  private ArgumentCaptor<Collection<EventLog>> eventLogsCapture;
+    @Captor
+    private ArgumentCaptor<Collection<EventLog>> eventLogsCapture;
 
-  private EventLogWriterImpl eventLogWriter;
+    private EventLogWriterImpl eventLogWriter;
 
-  private MockPayload eventPayload1;
-  private MockPayload eventPayload2;
-  private MockPayload eventPayload3;
+    private MockPayload eventPayload1;
+    private MockPayload eventPayload2;
+    private MockPayload eventPayload3;
 
-  private static final String TRACE_ID = "TRACE_ID";
+    private static final String TRACE_ID = "TRACE_ID";
 
-  private static final String EVENT_BODY_DATA_1 =
-      ("{'id':1,"
-          + "'code':'mockedcode1',"
-          + "'more':{'info':'some info'},"
-          + "'items':[{'detail':'some detail0'},{'detail':'some detail1'}],"
-          + "'active':true"
-          + "}").replace('\'', '"');
+    private static final String EVENT_BODY_DATA_1 =
+        ("{'id':1,"
+            + "'code':'mockedcode1',"
+            + "'more':{'info':'some info'},"
+            + "'items':[{'detail':'some detail0'},{'detail':'some detail1'}],"
+            + "'active':true"
+            + "}").replace('\'', '"');
 
-  private static final String EVENT_BODY_DATA_2 =
-      ("{'id':2,"
-          + "'code':'mockedcode2',"
-          + "'more':{'info':'some info'},"
-          + "'items':[{'detail':'some detail0'},{'detail':'some detail1'}],"
-          + "'active':true"
-          + "}").replace('\'', '"');
+    private static final String EVENT_BODY_DATA_2 =
+        ("{'id':2,"
+            + "'code':'mockedcode2',"
+            + "'more':{'info':'some info'},"
+            + "'items':[{'detail':'some detail0'},{'detail':'some detail1'}],"
+            + "'active':true"
+            + "}").replace('\'', '"');
 
-  private static final String EVENT_BODY_DATA_3 =
-      ("{'id':3,"
-          + "'code':'mockedcode3',"
-          + "'more':{'info':'some info'},"
-          + "'items':[{'detail':'some detail0'},{'detail':'some detail1'}],"
-          + "'active':true"
-          + "}").replace('\'', '"');
+    private static final String EVENT_BODY_DATA_3 =
+        ("{'id':3,"
+            + "'code':'mockedcode3',"
+            + "'more':{'info':'some info'},"
+            + "'items':[{'detail':'some detail0'},{'detail':'some detail1'}],"
+            + "'active':true"
+            + "}").replace('\'', '"');
 
-  private static final String PUBLISHER_DATA_TYPE_1 = "nakadi:some-publisher";
+    private static final String PUBLISHER_DATA_TYPE_1 = "nakadi:some-publisher";
 
-  private static final String DATA_CHANGE_BODY_DATA_1 = ("{'data_op':'{DATA_OP}','data_type':'" +
-      PUBLISHER_DATA_TYPE_1 + "','data':" + EVENT_BODY_DATA_1
-      + "}").replace('\'', '"');
+    private static final String DATA_CHANGE_BODY_DATA_1 = ("{'data_op':'{DATA_OP}','data_type':'" +
+        PUBLISHER_DATA_TYPE_1 + "','data':" + EVENT_BODY_DATA_1
+        + "}").replace('\'', '"');
 
-  private static final String DATA_CHANGE_BODY_DATA_2 = ("{'data_op':'{DATA_OP}','data_type':'" +
-      PUBLISHER_DATA_TYPE_1 + "','data':" + EVENT_BODY_DATA_2
-      + "}").replace('\'', '"');
+    private static final String DATA_CHANGE_BODY_DATA_2 = ("{'data_op':'{DATA_OP}','data_type':'" +
+        PUBLISHER_DATA_TYPE_1 + "','data':" + EVENT_BODY_DATA_2
+        + "}").replace('\'', '"');
 
-  private static final String DATA_CHANGE_BODY_DATA_3 = ("{'data_op':'{DATA_OP}','data_type':'" +
-      PUBLISHER_DATA_TYPE_1 + "','data':" + EVENT_BODY_DATA_3
-      + "}").replace('\'', '"');
+    private static final String DATA_CHANGE_BODY_DATA_3 = ("{'data_op':'{DATA_OP}','data_type':'" +
+        PUBLISHER_DATA_TYPE_1 + "','data':" + EVENT_BODY_DATA_3
+        + "}").replace('\'', '"');
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  @Before
-  public void setUp() {
-    Mockito.reset(eventLogRepository, flowIdComponent);
+    @Before
+    public void setUp() {
+        Mockito.reset(eventLogRepository, flowIdComponent);
 
-    eventPayload1 = Fixture.mockPayload(1, "mockedcode1", true,
-        Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
+        eventPayload1 = Fixture.mockPayload(1, "mockedcode1", true,
+            Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
 
-    eventPayload2 = Fixture.mockPayload(2, "mockedcode2", true,
-        Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
+        eventPayload2 = Fixture.mockPayload(2, "mockedcode2", true,
+            Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
 
-    eventPayload3 = Fixture.mockPayload(3, "mockedcode3", true,
-        Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
+        eventPayload3 = Fixture.mockPayload(3, "mockedcode3", true,
+            Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
 
-    when(flowIdComponent.getXFlowIdValue()).thenReturn(TRACE_ID);
+        when(flowIdComponent.getXFlowIdValue()).thenReturn(TRACE_ID);
 
-    eventLogWriter = new EventLogWriterImpl(eventLogRepository, new ObjectMapper(),
-        flowIdComponent);
-  }
+        eventLogWriter = new EventLogWriterImpl(eventLogRepository, new ObjectMapper(),
+            flowIdComponent);
+    }
 
-  @Test
-  public void testFireCreateEvent() {
-    eventLogWriter.fireCreateEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
+    @Test
+    public void testFireCreateEvent() {
+        eventLogWriter.fireCreateEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
 
-    verify(eventLogRepository).persist(eventLogCapture.capture());
+        verify(eventLogRepository).persist(eventLogCapture.capture());
 
-    assertThat(eventLogCapture.getValue().getEventBodyData(), is(
-        DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "C")));
-    assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
-    assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
-    assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
-    assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
-  }
+        assertThat(eventLogCapture.getValue().getEventBodyData(), is(
+            DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "C")));
+        assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
+        assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
+        assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
+        assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+    }
 
-  @Test
-  public void testFireCreateEvents() {
-    eventLogWriter.fireCreateEvents(
-        PUBLISHER_EVENT_TYPE,
-        PUBLISHER_DATA_TYPE_1,
-        Arrays.asList(eventPayload1, eventPayload2, eventPayload3)
-    );
-    verify(eventLogRepository).persist(eventLogsCapture.capture());
+    @Test
+    public void testFireCreateEvents() {
+        eventLogWriter.fireCreateEvents(
+            PUBLISHER_EVENT_TYPE,
+            PUBLISHER_DATA_TYPE_1,
+            Arrays.asList(eventPayload1, eventPayload2, eventPayload3)
+        );
+        verify(eventLogRepository).persist(eventLogsCapture.capture());
 
-    verifyEventLogs("C", new HashSet<>(eventLogsCapture.getValue()));
-  }
+        verifyEventLogs("C", new HashSet<>(eventLogsCapture.getValue()));
+    }
 
-  @Test
-  public void testFireUpdateEvent() {
-    eventLogWriter.fireUpdateEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
+    @Test
+    public void testFireUpdateEvent() {
+        eventLogWriter.fireUpdateEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
 
-    verify(eventLogRepository).persist(eventLogCapture.capture());
+        verify(eventLogRepository).persist(eventLogCapture.capture());
 
-    assertThat(eventLogCapture.getValue().getEventBodyData(), is(
-        DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "U")));
-    assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
-    assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
-    assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
-    assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
-  }
+        assertThat(eventLogCapture.getValue().getEventBodyData(), is(
+            DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "U")));
+        assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
+        assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
+        assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
+        assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+    }
 
-  @Test
-  public void testFireUpdateEvents() {
-    eventLogWriter.fireUpdateEvents(
-        PUBLISHER_EVENT_TYPE,
-        PUBLISHER_DATA_TYPE_1,
-        Arrays.asList(eventPayload1, eventPayload2, eventPayload3)
-    );
-    verify(eventLogRepository).persist(eventLogsCapture.capture());
+    @Test
+    public void testFireUpdateEvents() {
+        eventLogWriter.fireUpdateEvents(
+            PUBLISHER_EVENT_TYPE,
+            PUBLISHER_DATA_TYPE_1,
+            Arrays.asList(eventPayload1, eventPayload2, eventPayload3)
+        );
+        verify(eventLogRepository).persist(eventLogsCapture.capture());
 
-    verifyEventLogs("U", new HashSet<>(eventLogsCapture.getValue()));
-  }
+        verifyEventLogs("U", new HashSet<>(eventLogsCapture.getValue()));
+    }
 
-  @Test
-  public void testFireDeleteEvent() {
-    eventLogWriter.fireDeleteEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
+    @Test
+    public void testFireDeleteEvent() {
+        eventLogWriter.fireDeleteEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
 
-    verify(eventLogRepository).persist(eventLogCapture.capture());
+        verify(eventLogRepository).persist(eventLogCapture.capture());
 
-    assertThat(eventLogCapture.getValue().getEventBodyData(), is(
-        DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "D")));
-    assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
-    assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
-    assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
-    assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
-  }
+        assertThat(eventLogCapture.getValue().getEventBodyData(), is(
+            DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "D")));
+        assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
+        assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
+        assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
+        assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+    }
 
-  @Test
-  public void testFireDeleteEvents() {
-    eventLogWriter.fireDeleteEvents(
-        PUBLISHER_EVENT_TYPE,
-        PUBLISHER_DATA_TYPE_1,
-        Arrays.asList(eventPayload1, eventPayload2, eventPayload3));
-    verify(eventLogRepository).persist(eventLogsCapture.capture());
+    @Test
+    public void testFireDeleteEvents() {
+        eventLogWriter.fireDeleteEvents(
+            PUBLISHER_EVENT_TYPE,
+            PUBLISHER_DATA_TYPE_1,
+            Arrays.asList(eventPayload1, eventPayload2, eventPayload3));
+        verify(eventLogRepository).persist(eventLogsCapture.capture());
 
-    verifyEventLogs("D", new HashSet<>(eventLogsCapture.getValue()));
-  }
+        verifyEventLogs("D", new HashSet<>(eventLogsCapture.getValue()));
+    }
 
-  @Test
-  public void testFireSnapshotEvent() throws Exception {
-    eventLogWriter.fireSnapshotEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
+    @Test
+    public void testFireSnapshotEvent() throws Exception {
+        eventLogWriter.fireSnapshotEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1,
+            eventPayload1);
 
-    verify(eventLogRepository).persist(eventLogCapture.capture());
+        verify(eventLogRepository).persist(eventLogCapture.capture());
 
-    assertThat(eventLogCapture.getValue().getEventBodyData(), is(
-        DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "S")));
-    assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
-    assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
-    assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
-    assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
-  }
+        assertThat(eventLogCapture.getValue().getEventBodyData(), is(
+            DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "S")));
+        assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
+        assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
+        assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
+        assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+    }
 
-  @Test
-  public void testFireSnapshotEvents() {
-    eventLogWriter.fireSnapshotEvents(
-        PUBLISHER_EVENT_TYPE,
-        PUBLISHER_DATA_TYPE_1,
-        Arrays.asList(eventPayload1, eventPayload2, eventPayload3));
-    verify(eventLogRepository).persist(eventLogsCapture.capture());
+    @Test
+    public void testFireSnapshotEvents() {
+        eventLogWriter.fireSnapshotEvents(
+            PUBLISHER_EVENT_TYPE,
+            PUBLISHER_DATA_TYPE_1,
+            Arrays.asList(eventPayload1, eventPayload2, eventPayload3));
+        verify(eventLogRepository).persist(eventLogsCapture.capture());
 
-    verifyEventLogs("S", new HashSet<>(eventLogsCapture.getValue()));
-  }
+        verifyEventLogs("S", new HashSet<>(eventLogsCapture.getValue()));
+    }
 
-  @Test
-  public void testFireBusinessEvent() throws Exception {
-    MockPayload mockPayload = Fixture.mockPayload(1, "mockedcode1", true,
-        Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
+    @Test
+    public void testFireBusinessEvent() throws Exception {
+        MockPayload mockPayload = Fixture.mockPayload(1, "mockedcode1", true,
+            Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
 
-    eventLogWriter.fireBusinessEvent(PUBLISHER_EVENT_TYPE, mockPayload);
+        eventLogWriter.fireBusinessEvent(PUBLISHER_EVENT_TYPE, mockPayload);
 
-    verify(eventLogRepository).persist(eventLogCapture.capture());
+        verify(eventLogRepository).persist(eventLogCapture.capture());
 
-    assertThat(eventLogCapture.getValue().getEventBodyData(), is(EVENT_BODY_DATA_1));
-    assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
-    assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
-    assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
-    assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
-  }
+        assertThat(eventLogCapture.getValue().getEventBodyData(), is(EVENT_BODY_DATA_1));
+        assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
+        assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
+        assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
+        assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+    }
 
-  @Test
-  public void testFireBusinessEvents() throws Exception {
-    MockPayload mockPayload1 = Fixture.mockPayload(1, "mockedcode1", true,
-        Fixture.mockSubClass("some info 1_0"), Fixture.mockSubList(2, "some detail 1_2"));
-    MockPayload mockPayload2 = Fixture.mockPayload(2, "mockedcode2", true,
-        Fixture.mockSubClass("some info 2_0"), Fixture.mockSubList(2, "some detail 2_1"));
+    @Test
+    public void testFireBusinessEvents() throws Exception {
+        MockPayload mockPayload1 = Fixture.mockPayload(1, "mockedcode1", true,
+            Fixture.mockSubClass("some info 1_0"), Fixture.mockSubList(2, "some detail 1_2"));
+        MockPayload mockPayload2 = Fixture.mockPayload(2, "mockedcode2", true,
+            Fixture.mockSubClass("some info 2_0"), Fixture.mockSubList(2, "some detail 2_1"));
 
-    eventLogWriter.fireBusinessEvents(PUBLISHER_EVENT_TYPE,
-        Stream.of(mockPayload1, mockPayload2).collect(Collectors.toList()));
+        eventLogWriter.fireBusinessEvents(PUBLISHER_EVENT_TYPE,
+            Stream.of(mockPayload1, mockPayload2).collect(Collectors.toList()));
 
-    verify(eventLogRepository).persist(eventLogsCapture.capture());
+        verify(eventLogRepository).persist(eventLogsCapture.capture());
 
-    Iterator<EventLog> eventLogIterator = eventLogsCapture.getValue().iterator();
-    EventLog eventLog1 = eventLogIterator.next();
-    assertThat(eventLog1.getEventBodyData(), is(OBJECT_MAPPER.writeValueAsString(mockPayload1)));
-    assertThat(eventLog1.getEventType(), is(PUBLISHER_EVENT_TYPE));
-    assertThat(eventLog1.getFlowId(), is(TRACE_ID));
-    assertThat(eventLog1.getLockedBy(), is(nullValue()));
-    assertThat(eventLog1.getLockedUntil(), is(nullValue()));
+        Iterator<EventLog> eventLogIterator = eventLogsCapture.getValue().iterator();
+        EventLog eventLog1 = eventLogIterator.next();
+        assertThat(eventLog1.getEventBodyData(),
+            is(OBJECT_MAPPER.writeValueAsString(mockPayload1)));
+        assertThat(eventLog1.getEventType(), is(PUBLISHER_EVENT_TYPE));
+        assertThat(eventLog1.getFlowId(), is(TRACE_ID));
+        assertThat(eventLog1.getLockedBy(), is(nullValue()));
+        assertThat(eventLog1.getLockedUntil(), is(nullValue()));
 
-    EventLog eventLog2 = eventLogIterator.next();
-    assertThat(eventLog2.getEventBodyData(), is(OBJECT_MAPPER.writeValueAsString(mockPayload2)));
-    assertThat(eventLog2.getEventType(), is(PUBLISHER_EVENT_TYPE));
-    assertThat(eventLog2.getFlowId(), is(TRACE_ID));
-    assertThat(eventLog2.getLockedBy(), is(nullValue()));
-    assertThat(eventLog2.getLockedUntil(), is(nullValue()));
-  }
+        EventLog eventLog2 = eventLogIterator.next();
+        assertThat(eventLog2.getEventBodyData(),
+            is(OBJECT_MAPPER.writeValueAsString(mockPayload2)));
+        assertThat(eventLog2.getEventType(), is(PUBLISHER_EVENT_TYPE));
+        assertThat(eventLog2.getFlowId(), is(TRACE_ID));
+        assertThat(eventLog2.getLockedBy(), is(nullValue()));
+        assertThat(eventLog2.getLockedUntil(), is(nullValue()));
+    }
 
-  private void verifyEventLogs(String dataOp, Set<EventLog> eventLogs) {
-    Optional<EventLog> firstEventLog = eventLogs.stream().filter(
-        eventLog -> eventLog.getEventBodyData().contains("mockedcode1")).findFirst();
-    assertThat(firstEventLog.isPresent(), is(true));
-    assertThat(firstEventLog.get().getEventBodyData(), is(
-        DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", dataOp)));
-    assertThat(firstEventLog.get().getEventType(), is(PUBLISHER_EVENT_TYPE));
-    assertThat(firstEventLog.get().getFlowId(), is(TRACE_ID));
-    assertThat(firstEventLog.get().getLockedBy(), is(nullValue()));
-    assertThat(firstEventLog.get().getLockedUntil(), is(nullValue()));
+    private void verifyEventLogs(String dataOp, Set<EventLog> eventLogs) {
+        Optional<EventLog> firstEventLog = eventLogs.stream().filter(
+            eventLog -> eventLog.getEventBodyData().contains("mockedcode1")).findFirst();
+        assertThat(firstEventLog.isPresent(), is(true));
+        assertThat(firstEventLog.get().getEventBodyData(), is(
+            DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", dataOp)));
+        assertThat(firstEventLog.get().getEventType(), is(PUBLISHER_EVENT_TYPE));
+        assertThat(firstEventLog.get().getFlowId(), is(TRACE_ID));
+        assertThat(firstEventLog.get().getLockedBy(), is(nullValue()));
+        assertThat(firstEventLog.get().getLockedUntil(), is(nullValue()));
 
-    Optional<EventLog> secondEventLog = eventLogs.stream().filter(
-        eventLog -> eventLog.getEventBodyData().contains("mockedcode2")).findFirst();
-    assertThat(secondEventLog.isPresent(), is(true));
-    assertThat(secondEventLog.get().getEventBodyData(), is(
-        DATA_CHANGE_BODY_DATA_2.replace("{DATA_OP}", dataOp)));
-    assertThat(secondEventLog.get().getEventType(), is(PUBLISHER_EVENT_TYPE));
-    assertThat(secondEventLog.get().getFlowId(), is(TRACE_ID));
-    assertThat(secondEventLog.get().getLockedBy(), is(nullValue()));
-    assertThat(secondEventLog.get().getLockedUntil(), is(nullValue()));
+        Optional<EventLog> secondEventLog = eventLogs.stream().filter(
+            eventLog -> eventLog.getEventBodyData().contains("mockedcode2")).findFirst();
+        assertThat(secondEventLog.isPresent(), is(true));
+        assertThat(secondEventLog.get().getEventBodyData(), is(
+            DATA_CHANGE_BODY_DATA_2.replace("{DATA_OP}", dataOp)));
+        assertThat(secondEventLog.get().getEventType(), is(PUBLISHER_EVENT_TYPE));
+        assertThat(secondEventLog.get().getFlowId(), is(TRACE_ID));
+        assertThat(secondEventLog.get().getLockedBy(), is(nullValue()));
+        assertThat(secondEventLog.get().getLockedUntil(), is(nullValue()));
 
-    Optional<EventLog> thirdEventLog = eventLogs.stream().filter(
-        eventLog -> eventLog.getEventBodyData().contains("mockedcode3")).findFirst();
-    assertThat(thirdEventLog.isPresent(), is(true));
-    assertThat(thirdEventLog.get().getEventBodyData(), is(
-        DATA_CHANGE_BODY_DATA_3.replace("{DATA_OP}", dataOp)));
-    assertThat(thirdEventLog.get().getEventType(), is(PUBLISHER_EVENT_TYPE));
-    assertThat(thirdEventLog.get().getFlowId(), is(TRACE_ID));
-    assertThat(thirdEventLog.get().getLockedBy(), is(nullValue()));
-    assertThat(thirdEventLog.get().getLockedUntil(), is(nullValue()));
-  }
+        Optional<EventLog> thirdEventLog = eventLogs.stream().filter(
+            eventLog -> eventLog.getEventBodyData().contains("mockedcode3")).findFirst();
+        assertThat(thirdEventLog.isPresent(), is(true));
+        assertThat(thirdEventLog.get().getEventBodyData(), is(
+            DATA_CHANGE_BODY_DATA_3.replace("{DATA_OP}", dataOp)));
+        assertThat(thirdEventLog.get().getEventType(), is(PUBLISHER_EVENT_TYPE));
+        assertThat(thirdEventLog.get().getFlowId(), is(TRACE_ID));
+        assertThat(thirdEventLog.get().getLockedBy(), is(nullValue()));
+        assertThat(thirdEventLog.get().getLockedUntil(), is(nullValue()));
+    }
 
 }

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
@@ -7,8 +7,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.zalando.nakadiproducer.util.Fixture.PUBLISHER_EVENT_TYPE;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Before;
@@ -27,144 +34,262 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @RunWith(MockitoJUnitRunner.class)
 public class EventLogWriterTest {
 
-    @Mock
-    private EventLogRepository eventLogRepository;
+  @Mock
+  private EventLogRepository eventLogRepository;
 
-    @Mock
-    private FlowIdComponent flowIdComponent;
+  @Mock
+  private FlowIdComponent flowIdComponent;
 
-    @Captor
-    private ArgumentCaptor<EventLog> eventLogCapture;
+  @Captor
+  private ArgumentCaptor<EventLog> eventLogCapture;
 
-    @Captor
-    private ArgumentCaptor<Collection<EventLog>> eventLogCaptures;
+  @Captor
+  private ArgumentCaptor<Collection<EventLog>> eventLogsCapture;
 
-    private EventLogWriterImpl eventLogWriter;
+  private EventLogWriterImpl eventLogWriter;
 
-    private MockPayload eventPayload;
+  private MockPayload eventPayload1;
+  private MockPayload eventPayload2;
+  private MockPayload eventPayload3;
 
-    private static final String TRACE_ID = "TRACE_ID";
+  private static final String TRACE_ID = "TRACE_ID";
 
-    private static final String EVENT_BODY_DATA =
-            ("{'id':1,"
-                    + "'code':'mockedcode',"
-                    + "'more':{'info':'some info'},"
-                    + "'items':[{'detail':'some detail0'},{'detail':'some detail1'}],"
-                    + "'active':true"
-                    + "}").replace('\'', '"');
+  private static final String EVENT_BODY_DATA_1 =
+      ("{'id':1,"
+          + "'code':'mockedcode1',"
+          + "'more':{'info':'some info'},"
+          + "'items':[{'detail':'some detail0'},{'detail':'some detail1'}],"
+          + "'active':true"
+          + "}").replace('\'', '"');
 
-    private static final String DATA_CHANGE_BODY_DATA = ("{'data_op':'{DATA_OP}','data_type':'nakadi:some-publisher','data':" + EVENT_BODY_DATA + "}").replace('\'', '"');
-    private static final String PUBLISHER_DATA_TYPE = "nakadi:some-publisher";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String EVENT_BODY_DATA_2 =
+      ("{'id':2,"
+          + "'code':'mockedcode2',"
+          + "'more':{'info':'some info'},"
+          + "'items':[{'detail':'some detail0'},{'detail':'some detail1'}],"
+          + "'active':true"
+          + "}").replace('\'', '"');
 
-    @Before
-    public void setUp() throws Exception {
-        eventPayload = Fixture.mockPayload(1, "mockedcode", true,
-                Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
+  private static final String EVENT_BODY_DATA_3 =
+      ("{'id':3,"
+          + "'code':'mockedcode3',"
+          + "'more':{'info':'some info'},"
+          + "'items':[{'detail':'some detail0'},{'detail':'some detail1'}],"
+          + "'active':true"
+          + "}").replace('\'', '"');
 
-        when(flowIdComponent.getXFlowIdValue()).thenReturn(TRACE_ID);
+  private static final String PUBLISHER_DATA_TYPE_1 = "nakadi:some-publisher";
+  private static final String PUBLISHER_DATA_TYPE_2 = "nakadi:some-publisher2";
 
-        eventLogWriter = new EventLogWriterImpl(eventLogRepository, new ObjectMapper(), flowIdComponent);
-    }
+  private static final String DATA_CHANGE_BODY_DATA_1 = ("{'data_op':'{DATA_OP}','data_type':'" +
+      PUBLISHER_DATA_TYPE_1 + "','data':" + EVENT_BODY_DATA_1
+      + "}").replace('\'', '"');
 
-    @Test
-    public void testFireCreateEvent() throws Exception {
-        eventLogWriter.fireCreateEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload);
-        verify(eventLogRepository).persist(eventLogCapture.capture());
+  private static final String DATA_CHANGE_BODY_DATA_2 = ("{'data_op':'{DATA_OP}','data_type':'" +
+      PUBLISHER_DATA_TYPE_1 + "','data':" + EVENT_BODY_DATA_2
+      + "}").replace('\'', '"');
 
-        assertThat(eventLogCapture.getValue().getEventBodyData(), is(DATA_CHANGE_BODY_DATA.replace("{DATA_OP}", "C")));
-        assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
-        assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
-        assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
-        assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+  private static final String DATA_CHANGE_BODY_DATA_3 = ("{'data_op':'{DATA_OP}','data_type':'" +
+      PUBLISHER_DATA_TYPE_2 + "','data':" + EVENT_BODY_DATA_3
+      + "}").replace('\'', '"');
 
-    }
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    @Test
-    public void testFireUpdateEvent() throws Exception {
+  @Before
+  public void setUp() {
+    eventPayload1 = Fixture.mockPayload(1, "mockedcode1", true,
+        Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
 
-        eventLogWriter.fireUpdateEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload);
+    eventPayload2 = Fixture.mockPayload(2, "mockedcode2", true,
+        Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
 
-        verify(eventLogRepository).persist(eventLogCapture.capture());
+    eventPayload3 = Fixture.mockPayload(3, "mockedcode3", true,
+        Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
 
-        assertThat(eventLogCapture.getValue().getEventBodyData(), is(DATA_CHANGE_BODY_DATA.replace("{DATA_OP}", "U")));
-        assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
-        assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
-        assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
-        assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+    when(flowIdComponent.getXFlowIdValue()).thenReturn(TRACE_ID);
 
-    }
+    eventLogWriter = new EventLogWriterImpl(eventLogRepository, new ObjectMapper(),
+        flowIdComponent);
+  }
 
-    @Test
-    public void testFireDeleteEvent() throws Exception {
+  @Test
+  public void testFireCreateEvent() {
+    eventLogWriter.fireCreateEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
 
-        eventLogWriter.fireDeleteEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload);
+    verify(eventLogRepository).persist(eventLogCapture.capture());
 
-        verify(eventLogRepository).persist(eventLogCapture.capture());
+    assertThat(eventLogCapture.getValue().getEventBodyData(), is(
+        DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "C")));
+    assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
+    assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
+    assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
+    assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+  }
 
-        assertThat(eventLogCapture.getValue().getEventBodyData(), is(DATA_CHANGE_BODY_DATA.replace("{DATA_OP}", "D")));
-        assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
-        assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
-        assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
-        assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
-    }
+  @Test
+  public void testFireCreateEvents() {
+    Map<String, Collection<Object>> groupedData = new HashMap<>();
+    groupedData.put(PUBLISHER_DATA_TYPE_1, Arrays.asList(eventPayload1, eventPayload2));
+    groupedData.put(PUBLISHER_DATA_TYPE_2, Collections.singletonList(eventPayload3));
 
-    @Test
-    public void testFireSnapshotEvent() throws Exception {
+    eventLogWriter.fireCreateEvents(PUBLISHER_EVENT_TYPE, groupedData);
+    verify(eventLogRepository).persist(eventLogsCapture.capture());
 
-        eventLogWriter.fireSnapshotEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload);
+    verifyEventLogs("C", new HashSet<>(eventLogsCapture.getValue()));
+  }
 
-        verify(eventLogRepository).persist(eventLogCapture.capture());
+  @Test
+  public void testFireUpdateEvent() {
+    eventLogWriter.fireUpdateEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
 
-        assertThat(eventLogCapture.getValue().getEventBodyData(), is(DATA_CHANGE_BODY_DATA.replace("{DATA_OP}", "S")));
-        assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
-        assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
-        assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
-        assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
-    }
+    verify(eventLogRepository).persist(eventLogCapture.capture());
 
-    @Test
-    public void testFireBusinessEvent() throws Exception {
-        MockPayload mockPayload = Fixture.mockPayload(1, "mockedcode", true,
-                Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
+    assertThat(eventLogCapture.getValue().getEventBodyData(), is(
+        DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "U")));
+    assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
+    assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
+    assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
+    assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+  }
 
-        eventLogWriter.fireBusinessEvent(PUBLISHER_EVENT_TYPE, mockPayload);
+  @Test
+  public void testFireUpdateEvents() {
+    Map<String, Collection<Object>> groupedData = new HashMap<>();
+    groupedData.put(PUBLISHER_DATA_TYPE_1, Arrays.asList(eventPayload1, eventPayload2));
+    groupedData.put(PUBLISHER_DATA_TYPE_2, Collections.singletonList(eventPayload3));
 
-        verify(eventLogRepository).persist(eventLogCapture.capture());
+    eventLogWriter.fireUpdateEvents(PUBLISHER_EVENT_TYPE, groupedData);
+    verify(eventLogRepository).persist(eventLogsCapture.capture());
 
-        assertThat(eventLogCapture.getValue().getEventBodyData(), is(EVENT_BODY_DATA));
-        assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
-        assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
-        assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
-        assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
-    }
+    verifyEventLogs("U", new HashSet<>(eventLogsCapture.getValue()));
+  }
 
-    @Test
-    public void testFireBusinessEvents() throws Exception {
-      MockPayload mockPayload1 = Fixture.mockPayload(1, "mockedcode1", true,
-          Fixture.mockSubClass("some info 1_0"), Fixture.mockSubList(2, "some detail 1_2"));
-      MockPayload mockPayload2 = Fixture.mockPayload(2, "mockedcode2", true,
-          Fixture.mockSubClass("some info 2_0"), Fixture.mockSubList(2, "some detail 2_1"));
+  @Test
+  public void testFireDeleteEvent() {
+    eventLogWriter.fireDeleteEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
 
-      eventLogWriter.fireBusinessEvents(PUBLISHER_EVENT_TYPE,
-          Stream.of(mockPayload1, mockPayload2).collect(Collectors.toList()));
+    verify(eventLogRepository).persist(eventLogCapture.capture());
 
-      verify(eventLogRepository).persist(eventLogCaptures.capture());
+    assertThat(eventLogCapture.getValue().getEventBodyData(), is(
+        DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "D")));
+    assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
+    assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
+    assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
+    assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+  }
 
-      Iterator<EventLog> eventLogIterator = eventLogCaptures.getValue().iterator();
-      EventLog eventLog1 = eventLogIterator.next();
-      assertThat(eventLog1.getEventBodyData(), is(OBJECT_MAPPER.writeValueAsString(mockPayload1)));
-      assertThat(eventLog1.getEventType(), is(PUBLISHER_EVENT_TYPE));
-      assertThat(eventLog1.getFlowId(), is(TRACE_ID));
-      assertThat(eventLog1.getLockedBy(), is(nullValue()));
-      assertThat(eventLog1.getLockedUntil(), is(nullValue()));
+  @Test
+  public void testFireDeleteEvents() {
+    Map<String, Collection<Object>> groupedData = new HashMap<>();
+    groupedData.put(PUBLISHER_DATA_TYPE_1, Arrays.asList(eventPayload1, eventPayload2));
+    groupedData.put(PUBLISHER_DATA_TYPE_2, Collections.singletonList(eventPayload3));
 
-      EventLog eventLog2 = eventLogIterator.next();
-      assertThat(eventLog2.getEventBodyData(), is(OBJECT_MAPPER.writeValueAsString(mockPayload2)));
-      assertThat(eventLog2.getEventType(), is(PUBLISHER_EVENT_TYPE));
-      assertThat(eventLog2.getFlowId(), is(TRACE_ID));
-      assertThat(eventLog2.getLockedBy(), is(nullValue()));
-      assertThat(eventLog2.getLockedUntil(), is(nullValue()));
-    }
+    eventLogWriter.fireDeleteEvents(PUBLISHER_EVENT_TYPE, groupedData);
+    verify(eventLogRepository).persist(eventLogsCapture.capture());
+
+    verifyEventLogs("D", new HashSet<>(eventLogsCapture.getValue()));
+  }
+
+  @Test
+  public void testFireSnapshotEvent() throws Exception {
+    eventLogWriter.fireSnapshotEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE_1, eventPayload1);
+
+    verify(eventLogRepository).persist(eventLogCapture.capture());
+
+    assertThat(eventLogCapture.getValue().getEventBodyData(), is(
+        DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", "S")));
+    assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
+    assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
+    assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
+    assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+  }
+
+  @Test
+  public void testFireSnapshotEvents() {
+    Map<String, Collection<Object>> groupedData = new HashMap<>();
+    groupedData.put(PUBLISHER_DATA_TYPE_1, Arrays.asList(eventPayload1, eventPayload2));
+    groupedData.put(PUBLISHER_DATA_TYPE_2, Collections.singletonList(eventPayload3));
+
+    eventLogWriter.fireSnapshotEvents(PUBLISHER_EVENT_TYPE, groupedData);
+    verify(eventLogRepository).persist(eventLogsCapture.capture());
+
+    verifyEventLogs("S", new HashSet<>(eventLogsCapture.getValue()));
+  }
+
+  @Test
+  public void testFireBusinessEvent() throws Exception {
+    MockPayload mockPayload = Fixture.mockPayload(1, "mockedcode1", true,
+        Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
+
+    eventLogWriter.fireBusinessEvent(PUBLISHER_EVENT_TYPE, mockPayload);
+
+    verify(eventLogRepository).persist(eventLogCapture.capture());
+
+    assertThat(eventLogCapture.getValue().getEventBodyData(), is(EVENT_BODY_DATA_1));
+    assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
+    assertThat(eventLogCapture.getValue().getFlowId(), is(TRACE_ID));
+    assertThat(eventLogCapture.getValue().getLockedBy(), is(nullValue()));
+    assertThat(eventLogCapture.getValue().getLockedUntil(), is(nullValue()));
+  }
+
+  @Test
+  public void testFireBusinessEvents() throws Exception {
+    MockPayload mockPayload1 = Fixture.mockPayload(1, "mockedcode1", true,
+        Fixture.mockSubClass("some info 1_0"), Fixture.mockSubList(2, "some detail 1_2"));
+    MockPayload mockPayload2 = Fixture.mockPayload(2, "mockedcode2", true,
+        Fixture.mockSubClass("some info 2_0"), Fixture.mockSubList(2, "some detail 2_1"));
+
+    eventLogWriter.fireBusinessEvents(PUBLISHER_EVENT_TYPE,
+        Stream.of(mockPayload1, mockPayload2).collect(Collectors.toList()));
+
+    verify(eventLogRepository).persist(eventLogsCapture.capture());
+
+    Iterator<EventLog> eventLogIterator = eventLogsCapture.getValue().iterator();
+    EventLog eventLog1 = eventLogIterator.next();
+    assertThat(eventLog1.getEventBodyData(), is(OBJECT_MAPPER.writeValueAsString(mockPayload1)));
+    assertThat(eventLog1.getEventType(), is(PUBLISHER_EVENT_TYPE));
+    assertThat(eventLog1.getFlowId(), is(TRACE_ID));
+    assertThat(eventLog1.getLockedBy(), is(nullValue()));
+    assertThat(eventLog1.getLockedUntil(), is(nullValue()));
+
+    EventLog eventLog2 = eventLogIterator.next();
+    assertThat(eventLog2.getEventBodyData(), is(OBJECT_MAPPER.writeValueAsString(mockPayload2)));
+    assertThat(eventLog2.getEventType(), is(PUBLISHER_EVENT_TYPE));
+    assertThat(eventLog2.getFlowId(), is(TRACE_ID));
+    assertThat(eventLog2.getLockedBy(), is(nullValue()));
+    assertThat(eventLog2.getLockedUntil(), is(nullValue()));
+  }
+
+  private void verifyEventLogs(String dataOp, Set<EventLog> eventLogs) {
+    Optional<EventLog> firstEventLog = eventLogs.stream().filter(
+        eventLog -> eventLog.getEventBodyData().contains("mockedcode1")).findFirst();
+    assertThat(firstEventLog.isPresent(), is(true));
+    assertThat(firstEventLog.get().getEventBodyData(), is(
+        DATA_CHANGE_BODY_DATA_1.replace("{DATA_OP}", dataOp)));
+    assertThat(firstEventLog.get().getEventType(), is(PUBLISHER_EVENT_TYPE));
+    assertThat(firstEventLog.get().getFlowId(), is(TRACE_ID));
+    assertThat(firstEventLog.get().getLockedBy(), is(nullValue()));
+    assertThat(firstEventLog.get().getLockedUntil(), is(nullValue()));
+
+    Optional<EventLog> secondEventLog = eventLogs.stream().filter(
+        eventLog -> eventLog.getEventBodyData().contains("mockedcode2")).findFirst();
+    assertThat(secondEventLog.isPresent(), is(true));
+    assertThat(secondEventLog.get().getEventBodyData(), is(
+        DATA_CHANGE_BODY_DATA_2.replace("{DATA_OP}", dataOp)));
+    assertThat(secondEventLog.get().getEventType(), is(PUBLISHER_EVENT_TYPE));
+    assertThat(secondEventLog.get().getFlowId(), is(TRACE_ID));
+    assertThat(secondEventLog.get().getLockedBy(), is(nullValue()));
+    assertThat(secondEventLog.get().getLockedUntil(), is(nullValue()));
+
+    Optional<EventLog> thirdEventLog = eventLogs.stream().filter(
+        eventLog -> eventLog.getEventBodyData().contains("mockedcode3")).findFirst();
+    assertThat(thirdEventLog.isPresent(), is(true));
+    assertThat(thirdEventLog.get().getEventBodyData(), is(
+        DATA_CHANGE_BODY_DATA_3.replace("{DATA_OP}", dataOp)));
+    assertThat(thirdEventLog.get().getEventType(), is(PUBLISHER_EVENT_TYPE));
+    assertThat(thirdEventLog.get().getFlowId(), is(TRACE_ID));
+    assertThat(thirdEventLog.get().getLockedBy(), is(nullValue()));
+    assertThat(thirdEventLog.get().getLockedUntil(), is(nullValue()));
+  }
 
 }

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
@@ -9,11 +9,8 @@ import static org.zalando.nakadiproducer.util.Fixture.PUBLISHER_EVENT_TYPE;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
 import org.zalando.nakadiproducer.util.Fixture;
@@ -79,7 +77,6 @@ public class EventLogWriterTest {
           + "}").replace('\'', '"');
 
   private static final String PUBLISHER_DATA_TYPE_1 = "nakadi:some-publisher";
-  private static final String PUBLISHER_DATA_TYPE_2 = "nakadi:some-publisher2";
 
   private static final String DATA_CHANGE_BODY_DATA_1 = ("{'data_op':'{DATA_OP}','data_type':'" +
       PUBLISHER_DATA_TYPE_1 + "','data':" + EVENT_BODY_DATA_1
@@ -90,13 +87,15 @@ public class EventLogWriterTest {
       + "}").replace('\'', '"');
 
   private static final String DATA_CHANGE_BODY_DATA_3 = ("{'data_op':'{DATA_OP}','data_type':'" +
-      PUBLISHER_DATA_TYPE_2 + "','data':" + EVENT_BODY_DATA_3
+      PUBLISHER_DATA_TYPE_1 + "','data':" + EVENT_BODY_DATA_3
       + "}").replace('\'', '"');
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Before
   public void setUp() {
+    Mockito.reset(eventLogRepository, flowIdComponent);
+
     eventPayload1 = Fixture.mockPayload(1, "mockedcode1", true,
         Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
 
@@ -128,11 +127,11 @@ public class EventLogWriterTest {
 
   @Test
   public void testFireCreateEvents() {
-    Map<String, Collection<Object>> groupedData = new HashMap<>();
-    groupedData.put(PUBLISHER_DATA_TYPE_1, Arrays.asList(eventPayload1, eventPayload2));
-    groupedData.put(PUBLISHER_DATA_TYPE_2, Collections.singletonList(eventPayload3));
-
-    eventLogWriter.fireCreateEvents(PUBLISHER_EVENT_TYPE, groupedData);
+    eventLogWriter.fireCreateEvents(
+        PUBLISHER_EVENT_TYPE,
+        PUBLISHER_DATA_TYPE_1,
+        Arrays.asList(eventPayload1, eventPayload2, eventPayload3)
+    );
     verify(eventLogRepository).persist(eventLogsCapture.capture());
 
     verifyEventLogs("C", new HashSet<>(eventLogsCapture.getValue()));
@@ -154,11 +153,11 @@ public class EventLogWriterTest {
 
   @Test
   public void testFireUpdateEvents() {
-    Map<String, Collection<Object>> groupedData = new HashMap<>();
-    groupedData.put(PUBLISHER_DATA_TYPE_1, Arrays.asList(eventPayload1, eventPayload2));
-    groupedData.put(PUBLISHER_DATA_TYPE_2, Collections.singletonList(eventPayload3));
-
-    eventLogWriter.fireUpdateEvents(PUBLISHER_EVENT_TYPE, groupedData);
+    eventLogWriter.fireUpdateEvents(
+        PUBLISHER_EVENT_TYPE,
+        PUBLISHER_DATA_TYPE_1,
+        Arrays.asList(eventPayload1, eventPayload2, eventPayload3)
+    );
     verify(eventLogRepository).persist(eventLogsCapture.capture());
 
     verifyEventLogs("U", new HashSet<>(eventLogsCapture.getValue()));
@@ -180,11 +179,10 @@ public class EventLogWriterTest {
 
   @Test
   public void testFireDeleteEvents() {
-    Map<String, Collection<Object>> groupedData = new HashMap<>();
-    groupedData.put(PUBLISHER_DATA_TYPE_1, Arrays.asList(eventPayload1, eventPayload2));
-    groupedData.put(PUBLISHER_DATA_TYPE_2, Collections.singletonList(eventPayload3));
-
-    eventLogWriter.fireDeleteEvents(PUBLISHER_EVENT_TYPE, groupedData);
+    eventLogWriter.fireDeleteEvents(
+        PUBLISHER_EVENT_TYPE,
+        PUBLISHER_DATA_TYPE_1,
+        Arrays.asList(eventPayload1, eventPayload2, eventPayload3));
     verify(eventLogRepository).persist(eventLogsCapture.capture());
 
     verifyEventLogs("D", new HashSet<>(eventLogsCapture.getValue()));
@@ -206,11 +204,10 @@ public class EventLogWriterTest {
 
   @Test
   public void testFireSnapshotEvents() {
-    Map<String, Collection<Object>> groupedData = new HashMap<>();
-    groupedData.put(PUBLISHER_DATA_TYPE_1, Arrays.asList(eventPayload1, eventPayload2));
-    groupedData.put(PUBLISHER_DATA_TYPE_2, Collections.singletonList(eventPayload3));
-
-    eventLogWriter.fireSnapshotEvents(PUBLISHER_EVENT_TYPE, groupedData);
+    eventLogWriter.fireSnapshotEvents(
+        PUBLISHER_EVENT_TYPE,
+        PUBLISHER_DATA_TYPE_1,
+        Arrays.asList(eventPayload1, eventPayload2, eventPayload3));
     verify(eventLogRepository).persist(eventLogsCapture.capture());
 
     verifyEventLogs("S", new HashSet<>(eventLogsCapture.getValue()));

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>20.3.1</version>
+    <version>20.3.2</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>20.3.2</version>
+    <version>20.4.0</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>20.4.0</version>
+    <version>21.0.0</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 


### PR DESCRIPTION
#140 Persist multiple events in batch

Sketch for the Release notes:

* When you fire multiple similar events at once (in the same transaction), you can now use the plural `fire*Events` methods to store them all in one go into the database, instead of one-by-one. This increases throughput.
* If you used EventLogRepository.persist directly (you shouldn't!), it was previously storing the database ID of the new object back into the EventLog object. This is not happening anymore (in exchange for more efficiency for bulk inserts).
