### PR TITLE
support compacted event types (#154) via spring beans

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,9 @@ your `application.properties` includes
 management.endpoints.web.exposure.include=snapshot-event-creation,your-other-endpoints,...`
 ```
 and if one or more Spring Beans implement the `org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator` interface.
+(Note that this will automatically together with the compaction key feature mentioned above,
+ if you have registered a compaction key extractor matching the type of the data objects in your snapshots.)
+
 The optional filter specifier of the trigger request will be passed as a string parameter to the
 SnapshotEventGenerator's `generateSnapshots` method and may be null, if none is given.
 

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ for sending events to a compacted event type.
 
 In some cases, like when there usually are large time gaps between producing events for the same compaction key,
 the risk of getting events for the same key out-of-order is small.
-For these cases, you just can define a bean of type [`CompactionKeyExtractor`](nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractor.java) , and then all events of that event
-type will get sent with a compaction key.
+For these cases, you just can define a bean of type [`CompactionKeyExtractor`](nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractor.java),
+and then all events of that event type will be sent with a compaction key.
 
 ```java
 @Configuration
@@ -260,7 +260,6 @@ For corner cases: You can have multiple such extractors for the same event type,
 matches the payload object (in undefined order) will be used.
 There are also some more factory methods with different signatures for more special cases, and you can also write
 your own implementation (but for the usual cases, the one shown here should be enough).
-
 
 ### Event snapshots (optional)
 
@@ -300,7 +299,7 @@ your `application.properties` includes
 management.endpoints.web.exposure.include=snapshot-event-creation,your-other-endpoints,...`
 ```
 and if one or more Spring Beans implement the `org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator` interface.
-(Note that this will automatically together with the compaction key feature mentioned above,
+(Note that this will automatically work together with the compaction key feature mentioned above,
  if you have registered a compaction key extractor matching the type of the data objects in your snapshots.)
 
 The optional filter specifier of the trigger request will be passed as a string parameter to the

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -23,7 +23,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.zalando.fahrschein.NakadiClient;
-import org.zalando.fahrschein.NakadiClientBuilder;
 import org.zalando.fahrschein.http.api.ContentEncoding;
 import org.zalando.fahrschein.http.api.RequestFactory;
 import org.zalando.fahrschein.http.simple.SimpleRequestFactory;
@@ -140,7 +139,7 @@ public class NakadiProducerAutoConfiguration {
 
     @Bean
     public EventLogWriter eventLogWriter(EventLogRepository eventLogRepository, ObjectMapper objectMapper,
-                                         FlowIdComponent flowIdComponent, List<CompactionKeyExtractor<?>> extractorList) {
+                                         FlowIdComponent flowIdComponent, List<CompactionKeyExtractor> extractorList) {
         return new EventLogWriterImpl(eventLogRepository, objectMapper, flowIdComponent, extractorList);
     }
 

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.zalando.fahrschein.NakadiClientBuilder;
 import org.zalando.fahrschein.http.api.ContentEncoding;
 import org.zalando.fahrschein.http.api.RequestFactory;
 import org.zalando.fahrschein.http.simple.SimpleRequestFactory;
+import org.zalando.nakadiproducer.eventlog.CompactionKeyExtractor;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
 import org.zalando.nakadiproducer.eventlog.impl.EventLogRepository;
 import org.zalando.nakadiproducer.eventlog.impl.EventLogRepositoryImpl;
@@ -139,8 +140,8 @@ public class NakadiProducerAutoConfiguration {
 
     @Bean
     public EventLogWriter eventLogWriter(EventLogRepository eventLogRepository, ObjectMapper objectMapper,
-            FlowIdComponent flowIdComponent) {
-        return new EventLogWriterImpl(eventLogRepository, objectMapper, flowIdComponent);
+                                         FlowIdComponent flowIdComponent, List<CompactionKeyExtractor<?>> extractorList) {
+        return new EventLogWriterImpl(eventLogRepository, objectMapper, flowIdComponent, extractorList);
     }
 
     @Bean

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryImpl.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryImpl.java
@@ -87,6 +87,7 @@ public class EventLogRepositoryImpl implements EventLogRepository {
               namedParameterMap.addValue("lastModified", now);
               namedParameterMap.addValue("lockedBy", eventLog.getLockedBy());
               namedParameterMap.addValue("lockedUntil", eventLog.getLockedUntil());
+              namedParameterMap.addValue("compactionKey", eventLog.getCompactionKey());
               return namedParameterMap;
             })
             .toArray(MapSqlParameterSource[]::new);
@@ -94,9 +95,9 @@ public class EventLogRepositoryImpl implements EventLogRepository {
       jdbcTemplate.batchUpdate(
           "INSERT INTO " +
               "    nakadi_events.event_log " +
-              "    (event_type, event_body_data, flow_id, created, last_modified, locked_by, locked_until) " +
+              "    (event_type, event_body_data, flow_id, created, last_modified, locked_by, locked_until, compaction_key)" +
               "VALUES " +
-              "    (:eventType, :eventBodyData, :flowId, :created, :lastModified, :lockedBy, :lockedUntil)",
+              "    (:eventType, :eventBodyData, :flowId, :created, :lastModified, :lockedBy, :lockedUntil, :compactionKey)",
           namedParameterMaps
       );
     }

--- a/nakadi-producer-spring-boot-starter/src/main/resources/db_nakadiproducer/migrations/V2/V2133546886.1.1__add_compaction_key.sql
+++ b/nakadi-producer-spring-boot-starter/src/main/resources/db_nakadiproducer/migrations/V2/V2133546886.1.1__add_compaction_key.sql
@@ -1,0 +1,3 @@
+ALTER TABLE  nakadi_events.event_log
+  ADD COLUMN compaction_key TEXT  NULL
+;

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/EndToEndTestIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/EndToEndTestIT.java
@@ -39,8 +39,6 @@ public class EndToEndTestIT extends BaseMockedExternalCommunicationIT {
     @Autowired
     private MockNakadiPublishingClient nakadiClient;
 
-
-
     @BeforeEach
     @AfterEach
     public void clearNakadiEvents() {
@@ -91,7 +89,6 @@ public class EndToEndTestIT extends BaseMockedExternalCommunicationIT {
         assertThat(read(value.get(0), "$.metadata[?]", where("partition_compaction_key").exists(true)),
                 is(empty()));
     }
-
 
     @Test
     public void businessEventsShouldBeSubmittedToNakadi() throws IOException {

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/EndToEndTestIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/EndToEndTestIT.java
@@ -3,8 +3,7 @@ package org.zalando.nakadiproducer;
 import static com.jayway.jsonpath.Criteria.where;
 import static com.jayway.jsonpath.JsonPath.read;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -13,12 +12,16 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.zalando.nakadiproducer.eventlog.CompactionKeyExtractor;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
 import org.zalando.nakadiproducer.transmission.MockNakadiPublishingClient;
 import org.zalando.nakadiproducer.transmission.impl.EventTransmitter;
 import org.zalando.nakadiproducer.util.Fixture;
 import org.zalando.nakadiproducer.util.MockPayload;
 
+@ContextConfiguration(classes = EndToEndTestIT.Config.class)
 public class EndToEndTestIT extends BaseMockedExternalCommunicationIT {
     private static final String MY_DATA_CHANGE_EVENT_TYPE = "myDataChangeEventType";
     private static final String SECOND_DATA_CHANGE_EVENT_TYPE = "secondDataChangeEventType";
@@ -35,6 +38,8 @@ public class EndToEndTestIT extends BaseMockedExternalCommunicationIT {
 
     @Autowired
     private MockNakadiPublishingClient nakadiClient;
+
+
 
     @BeforeEach
     @AfterEach
@@ -57,21 +62,34 @@ public class EndToEndTestIT extends BaseMockedExternalCommunicationIT {
         assertThat(read(value.get(0), "$.data.code"), is(CODE));
     }
 
-    // skip for now
-//    @Test
+    @Test
     public void compactionKeyIsPreserved() throws IOException {
         MockPayload payload = Fixture.mockPayload(1, CODE);
-//        eventLogWriter.registerCompactionKeyExtractor(SECOND_DATA_CHANGE_EVENT_TYPE, MockPayload.class, p -> COMPACTION_KEY);
         eventLogWriter.fireDeleteEvent(SECOND_DATA_CHANGE_EVENT_TYPE, PUBLISHER_DATA_TYPE, payload);
+        eventLogWriter.fireBusinessEvent(MY_BUSINESS_EVENT_TYPE, payload);
 
         eventTransmitter.sendEvents();
-        List<String> value = nakadiClient.getSentEvents(SECOND_DATA_CHANGE_EVENT_TYPE);
+
+        List<String> dataEvents = nakadiClient.getSentEvents(SECOND_DATA_CHANGE_EVENT_TYPE);
+        assertThat(dataEvents.size(), is(1));
+        assertThat(read(dataEvents.get(0), "$.metadata.partition_compaction_key"), is(COMPACTION_KEY));
+
+        List<String> businessEvents = nakadiClient.getSentEvents(MY_BUSINESS_EVENT_TYPE);
+        assertThat(businessEvents.size(), is(1));
+        assertThat(read(businessEvents.get(0), "$.metadata.partition_compaction_key"), is(CODE));
+    }
+
+    @Test
+    public void compactionKeyIsNotInvented() throws IOException {
+        MockPayload payload = Fixture.mockPayload(1, CODE);
+        eventLogWriter.fireDeleteEvent(MY_DATA_CHANGE_EVENT_TYPE, PUBLISHER_DATA_TYPE, payload);
+
+        eventTransmitter.sendEvents();
+        List<String> value = nakadiClient.getSentEvents(MY_DATA_CHANGE_EVENT_TYPE);
 
         assertThat(value.size(), is(1));
-        assertThat(read(value.get(0), "$.data_op"), is("D"));
-        assertThat(read(value.get(0), "$.data_type"), is(PUBLISHER_DATA_TYPE));
-        assertThat(read(value.get(0), "$.data.code"), is(CODE));
-        assertThat(read(value.get(0), "$.metadata.partition_compaction_key"), is(COMPACTION_KEY));
+        assertThat(read(value.get(0), "$.metadata[?]", where("partition_compaction_key").exists(true)),
+                is(empty()));
     }
 
 
@@ -94,5 +112,17 @@ public class EndToEndTestIT extends BaseMockedExternalCommunicationIT {
         assertThat(read(value.get(0), "$[?]", where("data_op").exists(true)), is(empty()));
         assertThat(read(value.get(0), "$[?]", where("data_type").exists(true)), is(empty()));
         assertThat(read(value.get(0), "$[?]", where("data").exists(true)), is(empty()));
+    }
+
+    public static class Config {
+        @Bean
+        public CompactionKeyExtractor compactionKeyExtractorForSecondDataEventType() {
+            return CompactionKeyExtractor.of(SECOND_DATA_CHANGE_EVENT_TYPE, MockPayload.class, m -> COMPACTION_KEY);
+        }
+
+        @Bean
+        public CompactionKeyExtractor keyExtractorForBusinessEventType() {
+            return CompactionKeyExtractor.of(MY_BUSINESS_EVENT_TYPE, MockPayload.class, MockPayload::getCode);
+        }
     }
 }

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/EndToEndTestIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/EndToEndTestIT.java
@@ -57,10 +57,11 @@ public class EndToEndTestIT extends BaseMockedExternalCommunicationIT {
         assertThat(read(value.get(0), "$.data.code"), is(CODE));
     }
 
-    @Test
+    // skip for now
+//    @Test
     public void compactionKeyIsPreserved() throws IOException {
         MockPayload payload = Fixture.mockPayload(1, CODE);
-        eventLogWriter.registerCompactionKeyExtractor(SECOND_DATA_CHANGE_EVENT_TYPE, MockPayload.class, p -> COMPACTION_KEY);
+//        eventLogWriter.registerCompactionKeyExtractor(SECOND_DATA_CHANGE_EVENT_TYPE, MockPayload.class, p -> COMPACTION_KEY);
         eventLogWriter.fireDeleteEvent(SECOND_DATA_CHANGE_EVENT_TYPE, PUBLISHER_DATA_TYPE, payload);
 
         eventTransmitter.sendEvents();

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryIT.java
@@ -38,18 +38,21 @@ public class EventLogRepositoryIT extends BaseMockedExternalCommunicationIT {
 
     private final String WAREHOUSE_EVENT_TYPE = "wholesale.warehouse-change-event";
 
+    public static final String COMPACTION_KEY = "COMPACTED";
+
     @Before
     public void setUp() {
         eventLogRepository.deleteAll();
 
         final EventLog eventLog = EventLog.builder().eventBodyData(WAREHOUSE_EVENT_BODY_DATA)
                                                                      .eventType(WAREHOUSE_EVENT_TYPE)
+                                                                     .compactionKey(COMPACTION_KEY)
                                                                      .flowId("FLOW_ID").build();
         eventLogRepository.persist(eventLog);
     }
 
     @Test
-    public void findEventRepositoryId() {
+    public void testFindEventInRepositoryById() {
         Integer id = jdbcTemplate.queryForObject(
             "SELECT id FROM nakadi_events.event_log WHERE flow_id = 'FLOW_ID'",
             Integer.class);
@@ -60,6 +63,7 @@ public class EventLogRepositoryIT extends BaseMockedExternalCommunicationIT {
     private void compareWithPersistedEvent(final EventLog eventLog) {
         assertThat(eventLog.getEventBodyData(), is(WAREHOUSE_EVENT_BODY_DATA));
         assertThat(eventLog.getEventType(), is(WAREHOUSE_EVENT_TYPE));
+        assertThat(eventLog.getCompactionKey(), is(COMPACTION_KEY));
     }
 
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractor.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractor.java
@@ -2,7 +2,7 @@ package org.zalando.nakadiproducer.eventlog;
 
 /**
  * This is a functional interface to be implemented by applications which want to produce compacted events.
- * In many cases it's possible to implement this with a method reference to a getter,
+ * In many cases it's possible to implement this with a method reference to a getter (like {@code Order::getNumber}),
  * in more complex cases it's usually still possible as a one-line Lambda.
  * @param <X> The (Java) type of objects for which the compaction key will be computed.
  * @see EventLogWriter#registerCompactionKeyExtractor(String, Class, CompactionKeyExtractor)

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractor.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractor.java
@@ -1,22 +1,76 @@
 package org.zalando.nakadiproducer.eventlog;
 
-import lombok.Data;
+import org.zalando.nakadiproducer.eventlog.CompactionKeyExtractors.SimpleCompactionKeyExtractor;
+import org.zalando.nakadiproducer.eventlog.CompactionKeyExtractors.TypedCompactionKeyExtractor;
 
 import java.util.Optional;
 import java.util.function.Function;
 
-@Data(staticConstructor = "of")
-public class CompactionKeyExtractor<X> {
-    private final String eventType;
-    private final Class<X> type;
-    private final Function<X, String> extractorFunction;
+/**
+ * This interface defines a way of extracting a compaction key from an object which
+ * is sent as a payload in a compacted event type.
+ * In most cases, for each compacted event type exactly one such object will be made known to the producer, and
+ * you can define it using {@link #of(String, Class, Function)}, passing a method reference or a lambda.
+ * For special occasions (e.g. where objects of different classes are used as payloads for the same event type)
+ * also multiple extractors for the same event type are supported – in this case any which returns a
+ * non-empty optional will be used.
+ */
+public interface CompactionKeyExtractor {
 
+    default String getKeyOrNull(Object payload) {
+        return tryGetKeyFor(payload).orElse(null);
+    }
 
-    public Optional<String> tryGetKeyFor(Object o) {
-        if(type.isInstance(o)) {
-            return Optional.of(extractorFunction.apply(type.cast(o)));
-        } else {
-            return Optional.empty();
-        }
+    Optional<String> tryGetKeyFor(Object o);
+
+    String getEventType();
+
+    /**
+     * A type-safe compaction key extractor. This will be the one to be used by most applications.
+     *
+     * @param eventType Indicates the event type. Only events sent to this event type will be considered.
+     * @param type  A Java type for payload objects. Only payload objects where {@code type.isInstance(payload)}
+     *             will be considered at all.
+     * @param extractorFunction A function extracting a compaction key from a payload object.
+     *                          This will commonly be given as a method reference or lambda.
+     * @return  A compaction key extractor, to be defined as a spring bean (if using the spring-boot starter)
+     *  or passed manually to the event log writer implementation (if using nakadi-producer directly).
+     *  (This should not return null.)
+     * @param <X> the type of {@code type} and input type of {@code extractorFunction}.
+     */
+    static <X> CompactionKeyExtractor of(String eventType, Class<X> type, Function<X, String> extractorFunction) {
+        return new TypedCompactionKeyExtractor<>(eventType, type, extractorFunction);
+    }
+
+    /**
+     * Non-type safe key extractor, returning an Optional.
+     * @param eventType The event type for which this extractor is intended.
+     * @param extractor The extractor function. It is supposed to return {@link Optional#empty()} if this extractor
+     *                 can't handle the input object, otherwise the actual key.
+     * @return a key extractor object.
+     */
+    static CompactionKeyExtractor ofOptional(String eventType, Function<Object, Optional<String>> extractor) {
+        return new SimpleCompactionKeyExtractor(eventType, extractor);
+    }
+
+    /**
+     * Non-type safe key extractor, returning null for unknown objects.
+     * @param eventType The event type for which this extractor is intended.
+     * @param extractor The extractor function. It is supposed to return {@code null} if this extractor
+     *                 can't handle the input object, otherwise the actual key.
+     * @return a key extractor object.
+     */
+    static CompactionKeyExtractor ofNullable(String eventType, Function<Object, String> extractor) {
+        return new SimpleCompactionKeyExtractor(eventType, extractor.andThen(Optional::ofNullable));
+    }
+
+    /**
+     * An universal key extractor, capable of handling all objects.
+     * @param eventType The event type for which this extractor is intended.
+     * @param extractor The extractor function. It is not allowed to return {@code null}.
+     * @return a key extractor object.
+     */
+    static CompactionKeyExtractor of(String eventType, Function<Object, String> extractor) {
+        return new SimpleCompactionKeyExtractor(eventType, extractor.andThen(Optional::of));
     }
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractor.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractor.java
@@ -1,0 +1,19 @@
+package org.zalando.nakadiproducer.eventlog;
+
+/**
+ * This is a functional interface to be implemented by applications which want to produce compacted events.
+ * In many cases it's possible to implement this with a method reference to a getter,
+ * in more complex cases it's usually still possible as a one-line Lambda.
+ * @param <X> The (Java) type of objects for which the compaction key will be computed.
+ * @see EventLogWriter#registerCompactionKeyExtractor(String, Class, CompactionKeyExtractor)
+ */
+@FunctionalInterface
+public interface CompactionKeyExtractor<X> {
+    /**
+     * Extracts a compaction key of a data object.
+     *
+     * @param data The data/payload to be sent in the event.
+     * @return the compaction key to be written in the metadata.
+     */
+    String getCompactionKeyFor(X data);
+}

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractor.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractor.java
@@ -1,19 +1,22 @@
 package org.zalando.nakadiproducer.eventlog;
 
-/**
- * This is a functional interface to be implemented by applications which want to produce compacted events.
- * In many cases it's possible to implement this with a method reference to a getter (like {@code Order::getNumber}),
- * in more complex cases it's usually still possible as a one-line Lambda.
- * @param <X> The (Java) type of objects for which the compaction key will be computed.
- * @see EventLogWriter#registerCompactionKeyExtractor(String, Class, CompactionKeyExtractor)
- */
-@FunctionalInterface
-public interface CompactionKeyExtractor<X> {
-    /**
-     * Extracts a compaction key of a data object.
-     *
-     * @param data The data/payload to be sent in the event.
-     * @return the compaction key to be written in the metadata.
-     */
-    String getCompactionKeyFor(X data);
+import lombok.Data;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+@Data(staticConstructor = "of")
+public class CompactionKeyExtractor<X> {
+    private final String eventType;
+    private final Class<X> type;
+    private final Function<X, String> extractorFunction;
+
+
+    public Optional<String> tryGetKeyFor(Object o) {
+        if(type.isInstance(o)) {
+            return Optional.of(extractorFunction.apply(type.cast(o)));
+        } else {
+            return Optional.empty();
+        }
+    }
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractors.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/CompactionKeyExtractors.java
@@ -1,0 +1,43 @@
+package org.zalando.nakadiproducer.eventlog;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * This class contains implementations of {@link CompactionKeyExtractor} used by the factory methods in that interface.
+ */
+final class CompactionKeyExtractors {
+
+    @AllArgsConstructor(access = AccessLevel.PACKAGE)
+    static class SimpleCompactionKeyExtractor implements CompactionKeyExtractor {
+        @Getter
+        private final String eventType;
+        private final Function<Object, Optional<String>> extractorFunction;
+
+        @Override
+        public Optional<String> tryGetKeyFor(Object o) {
+            return extractorFunction.apply(o);
+        }
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PACKAGE)
+    static class TypedCompactionKeyExtractor<X> implements CompactionKeyExtractor {
+        @Getter
+        private final String eventType;
+        private final Class<X> type;
+        private final Function<X, String> extractorFunction;
+
+        @Override
+        public Optional<String> tryGetKeyFor(Object o) {
+            if(type.isInstance(o)) {
+                return Optional.of(extractorFunction.apply(type.cast(o)));
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
@@ -231,5 +231,5 @@ public interface EventLogWriter {
    *            parameter)
    */
     @Transactional
-    void fireBusinessEvents(String eventType, Collection<Object> payloads);
+    void fireBusinessEvents(String eventType, Collection<?> payloads);
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
@@ -3,7 +3,6 @@ package org.zalando.nakadiproducer.eventlog;
 import java.util.Collection;
 import javax.transaction.Transactional;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
 
 /**
@@ -53,7 +52,7 @@ public interface EventLogWriter {
      * @param dataType the Java type of the objects for which the extractor is used.
      * @param extractor a function which will extract the compaction key from an object.
      */
-    <X> void registerCompactionKeyExtractor(String eventType, Class<X> dataType, CompactionKeyExtractor<X> extractor);
+//    <X> void registerCompactionKeyExtractor(String eventType, Class<X> dataType, CompactionKeyExtractorFunction<X> extractor);
 
     /**
      * Fires a data change event about a <b>creation</b> of some resource

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
@@ -23,38 +23,6 @@ import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
 public interface EventLogWriter {
 
     /**
-     * Registers a function for extracting compaction keys for events sent in the future.
-     * <p>
-     * When an event for this event type is sent out, and its `data` (or `payload`) object matches the type,
-     * the extractor is used to set the {@code partition_compaction_key} in the event to be sent out.
-     * For all other objects (or if the extractor returns null), no compaction key is set.
-     * </p>
-     *<p>
-     * (If multiple extractors are registered for the same event type, their data
-     *  type is checked in reverse order of registering, until a fitting one is found.
-     *  The first with matching dataType is used.)
-     * </p>
-     * <dl><dt>Note</dt>
-     * <dd>
-     *     Nakadi-Producer does <b>not</b> guarantee event ordering,
-     *     which is fundamentally incompatible with Nakadi's log-compaction mechanism,
-     *     as Nakadi will always keep just the last submitted event for the same compaction key,
-     *     which might not be the last produced one.
-     *     Still, in some special cases (e.g. when there is normally a long time between production
-     *     of events with the same compaction key, so all events will be sent out before the next group)
-     *     it is possible without problems (and these are also cases where the compaction is most useful).
-     *     <b>This feature is meant just for these special cases.</b>
-     *     </dd></dl>
-     * </p>
-     *
-     *
-     * @param eventType the event type for which this is used.
-     * @param dataType the Java type of the objects for which the extractor is used.
-     * @param extractor a function which will extract the compaction key from an object.
-     */
-//    <X> void registerCompactionKeyExtractor(String eventType, Class<X> dataType, CompactionKeyExtractorFunction<X> extractor);
-
-    /**
      * Fires a data change event about a <b>creation</b> of some resource
      * (object).
      *

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLog.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLog.java
@@ -25,5 +25,5 @@ public class EventLog {
     private Instant lastModified;
     private String lockedBy;
     private Instant lockedUntil;
-
+    private String compactionKey;
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
@@ -8,6 +8,8 @@ import static org.zalando.nakadiproducer.eventlog.impl.EventDataOperation.UPDATE
 
 import java.util.Collection;
 
+import lombok.AllArgsConstructor;
+import org.zalando.nakadiproducer.eventlog.CompactionKeyExtractor;
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
 
@@ -16,6 +18,9 @@ import javax.transaction.Transactional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class EventLogWriterImpl implements EventLogWriter {
 
     private final EventLogRepository eventLogRepository;
@@ -23,86 +28,104 @@ public class EventLogWriterImpl implements EventLogWriter {
     private final ObjectMapper objectMapper;
     private final FlowIdComponent flowIdComponent;
 
+    private final Map<String, CompactionExtractorWrapper<?>> extractors;
+
     public EventLogWriterImpl(EventLogRepository eventLogRepository, ObjectMapper objectMapper, FlowIdComponent flowIdComponent) {
         this.eventLogRepository = eventLogRepository;
         this.objectMapper = objectMapper;
         this.flowIdComponent = flowIdComponent;
+        this.extractors = new HashMap<>();
     }
 
     @Override
     @Transactional
     public void fireCreateEvent(final String eventType, final String dataType, final Object data) {
-        final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(CREATE.toString(), dataType, data));
+        final EventLog eventLog = createDataEventLog(eventType, CREATE, dataType, data);
         eventLogRepository.persist(eventLog);
     }
 
     @Override
     @Transactional
     public void fireCreateEvents(final String eventType, final String dataType, final Collection<?> data) {
-        eventLogRepository.persist(createEventLogs(eventType, CREATE, dataType, data));
+        eventLogRepository.persist(createDataEventLogs(eventType, CREATE, dataType, data));
     }
 
     @Override
     @Transactional
     public void fireUpdateEvent(final String eventType, final String dataType, final Object data) {
-        final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(UPDATE.toString(), dataType, data));
+        final EventLog eventLog = createDataEventLog(eventType, UPDATE, dataType, data);
         eventLogRepository.persist(eventLog);
     }
 
     @Override
     @Transactional
     public void fireUpdateEvents(final String eventType, final String dataType, final Collection<?> data) {
-        eventLogRepository.persist(createEventLogs(eventType, UPDATE, dataType, data));
+        eventLogRepository.persist(createDataEventLogs(eventType, UPDATE, dataType, data));
     }
 
     @Override
     @Transactional
     public void fireDeleteEvent(final String eventType, final String dataType, final Object data) {
-        final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(DELETE.toString(), dataType, data));
+        final EventLog eventLog = createDataEventLog(eventType, DELETE, dataType, data);
         eventLogRepository.persist(eventLog);
     }
 
     @Override
     @Transactional
     public void fireDeleteEvents(final String eventType, final String dataType, final Collection<?> data) {
-        eventLogRepository.persist(createEventLogs(eventType, DELETE, dataType, data));
+        eventLogRepository.persist(createDataEventLogs(eventType, DELETE, dataType, data));
     }
 
     @Override
     @Transactional
     public void fireSnapshotEvent(final String eventType, final String dataType, final Object data) {
-        final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(SNAPSHOT.toString(), dataType, data));
+        final EventLog eventLog = createDataEventLog(eventType, SNAPSHOT, dataType, data);
         eventLogRepository.persist(eventLog);
     }
 
     @Override
     @Transactional
     public void fireSnapshotEvents(final String eventType, final String dataType, final Collection<?> data) {
-        eventLogRepository.persist(createEventLogs(eventType, SNAPSHOT, dataType, data));
+        eventLogRepository.persist(createDataEventLogs(eventType, SNAPSHOT, dataType, data));
     }
 
     @Override
     @Transactional
     public void fireBusinessEvent(final String eventType, Object payload) {
-        final EventLog eventLog = createEventLog(eventType, payload);
+        final EventLog eventLog = createEventLog(eventType, payload, getCompactionKeyFor(eventType, payload));
         eventLogRepository.persist(eventLog);
     }
 
     @Override
     @Transactional
     public void fireBusinessEvents(final String eventType, final Collection<Object> payload) {
-        final Collection<EventLog> eventLogs = createEventLogs(eventType, payload);
+        final Collection<EventLog> eventLogs = createBusinessEventLogs(eventType, payload);
         eventLogRepository.persist(eventLogs);
     }
 
-    private Collection<EventLog> createEventLogs(final String eventType,
-                                                 final Collection<Object> eventPayloads) {
+    private Collection<EventLog> createBusinessEventLogs(final String eventType,
+                                                     final Collection<Object> eventPayloads) {
         return eventPayloads.stream()
-                .map(payload -> createEventLog(eventType, payload))
+                .map(payload -> createEventLog(eventType, payload, getCompactionKeyFor(eventType, payload)))
                 .collect(toList());
     }
 
-    private EventLog createEventLog(final String eventType, final Object eventPayload) {
+    private String getCompactionKeyFor(String eventType, Object payload) {
+        CompactionExtractorWrapper<?> extractorWrapper = extractors.get(eventType);
+        if (extractorWrapper != null) {
+            return extractorWrapper.extract(payload);
+        } else {
+            return null;
+        }
+    }
+
+
+    private EventLog createDataEventLog(String eventType, EventDataOperation dataOp, String dataType, Object data) {
+        return createEventLog(eventType, new DataChangeEventEnvelope(dataOp.toString(), dataType, data),
+                getCompactionKeyFor(eventType, data));
+    }
+
+    private EventLog createEventLog(final String eventType, final Object eventPayload, String compactionKey) {
         final EventLog eventLog = new EventLog();
         eventLog.setEventType(eventType);
         try {
@@ -115,16 +138,47 @@ public class EventLogWriterImpl implements EventLogWriter {
         return eventLog;
     }
 
-    private Collection<EventLog> createEventLogs(
+    private Collection<EventLog> createDataEventLogs(
             final String eventType,
             final EventDataOperation eventDataOperation,
             final String dataType,
             final Collection<?> data
     ) {
         return data.stream()
-                .map(payload -> createEventLog(eventType,
-                        new DataChangeEventEnvelope(eventDataOperation.toString(), dataType, payload)))
+                .map(payload -> createEventLog(
+                                    eventType,
+                                    new DataChangeEventEnvelope(eventDataOperation.toString(), dataType, payload),
+                                    getCompactionKeyFor(eventType, payload)))
                 .collect(toList());
+    }
+
+    /**
+     * This is a linked list of extractors (with type information), all for the same event type.
+     *
+     * @param <X>
+     */
+    @AllArgsConstructor
+    private static class CompactionExtractorWrapper<X> {
+        CompactionKeyExtractor<X> extractor;
+        Class<X> type;
+        CompactionExtractorWrapper<?> next;
+
+        String extract(Object o) {
+            if (o == null) {
+                return null;
+            } else if (type.isInstance(o)) {
+                return extractor.getCompactionKeyFor(type.cast(o));
+            } else if (next != null) {
+                return next.extract(o);
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public <X> void registerCompactionKeyExtractor(String eventType, Class<X> dataType, CompactionKeyExtractor<X> extractor) {
+        CompactionExtractorWrapper<?> next = extractors.get(eventType);
+        extractors.put(eventType, new CompactionExtractorWrapper<X>(extractor, dataType, next));
     }
 
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionService.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionService.java
@@ -126,7 +126,7 @@ public class EventTransmissionService {
     private boolean lockNearlyExpired(EventLog eventLog) {
         // since clocks never work exactly synchronous and sending the event also takes some time, we include a safety
         // buffer here. This is still not 100% precise, but since we require events to be consumed idempotent, sending
-        // one event twice wont hurt much.
+        // one event twice won't hurt much.
         return now().isAfter(eventLog.getLockedUntil().minus(lockDurationBuffer, SECONDS));
     }
 
@@ -137,6 +137,7 @@ public class EventTransmissionService {
         metadata.setEid(convertToUUID(event.getId()));
         metadata.setOccuredAt(event.getCreated());
         metadata.setFlowId(event.getFlowId());
+        metadata.setPartitionCompactionKey(event.getCompactionKey());
         nakadiEvent.setMetadata(metadata);
 
         LinkedHashMap<String, Object> payloadDTO = objectMapper.readValue(event.getEventBodyData(), new TypeReference<LinkedHashMap<String, Object>>() { });

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/NakadiMetadata.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/NakadiMetadata.java
@@ -20,4 +20,7 @@ public class NakadiMetadata {
     @JsonProperty("flow_id")
     private String flowId;
 
+    @JsonProperty("partition_compaction_key")
+    private String partitionCompactionKey;
+
 }

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterMultipleTypesTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterMultipleTypesTest.java
@@ -110,7 +110,6 @@ public class EventLogWriterMultipleTypesTest {
         assertThat(compactionKeys, contains(equalTo("Hello"), equalTo("World"), equalTo("List?")));
     }
 
-
     private List<String> getPersistedCompactionKeys() {
         verify(eventLogRepository).persist(eventLogsCapture.capture());
         Collection<EventLog> eventLogs = eventLogsCapture.getValue();

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterMultipleTypesTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterMultipleTypesTest.java
@@ -1,0 +1,119 @@
+package org.zalando.nakadiproducer.eventlog.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.zalando.nakadiproducer.flowid.FlowIdComponent;
+import org.zalando.nakadiproducer.util.Fixture;
+import org.zalando.nakadiproducer.util.MockPayload;
+
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.zalando.nakadiproducer.util.Fixture.PUBLISHER_EVENT_TYPE;
+
+/**
+ * This tests the cases where we have multiple CompactionKeyExtractors for different types.
+ */
+public class EventLogWriterMultipleTypesTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private EventLogRepository eventLogRepository;
+
+    @Mock
+    private FlowIdComponent flowIdComponent;
+
+    @Captor
+    private ArgumentCaptor<EventLog> eventLogCapture;
+
+    @Captor
+    private ArgumentCaptor<Collection<EventLog>> eventLogsCapture;
+
+    private EventLogWriterImpl eventLogWriter;
+
+    private static final String TRACE_ID = "TRACE_ID";
+
+    private MockPayload eventPayload1;
+    private MockPayload.SubClass eventPayload2;
+    private List<MockPayload.SubListItem> eventPayload3;
+
+    @Before
+    public void setUp() {
+        Mockito.reset(eventLogRepository, flowIdComponent);
+
+        eventPayload1 = Fixture.mockPayload(1, "mockedcode1", true,
+                Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
+
+        eventPayload2 = Fixture.mockSubClass("some info");
+
+        eventPayload3 = Fixture.mockSubList(2, "some detail");
+
+        when(flowIdComponent.getXFlowIdValue()).thenReturn(TRACE_ID);
+
+        eventLogWriter = new EventLogWriterImpl(eventLogRepository, new ObjectMapper(),
+                flowIdComponent);
+    }
+
+    @Test
+    public void noCompactionExtractors() {
+        eventLogWriter.fireCreateEvents(PUBLISHER_EVENT_TYPE, "",
+                asList(eventPayload1, eventPayload2, eventPayload3));
+        List<String> compactionKeys = getPersistedCompactionKeys();
+        assertThat(compactionKeys, contains(nullValue(), nullValue(), nullValue()));
+    }
+
+    @Test
+    public void oneCompactionExtractor() {
+        eventLogWriter.registerCompactionKeyExtractor(PUBLISHER_EVENT_TYPE, MockPayload.class, m -> "Hello");
+        eventLogWriter.fireCreateEvents(PUBLISHER_EVENT_TYPE, "",
+                asList(eventPayload1, eventPayload2, eventPayload3));
+        List<String> compactionKeys = getPersistedCompactionKeys();
+        assertThat(compactionKeys, contains(equalTo("Hello"), nullValue(), nullValue()));
+    }
+
+    @Test
+    public void twoCompactionExtractors() {
+        eventLogWriter.registerCompactionKeyExtractor(PUBLISHER_EVENT_TYPE, MockPayload.class, m -> "Hello");
+        eventLogWriter.registerCompactionKeyExtractor(PUBLISHER_EVENT_TYPE, MockPayload.SubClass.class, m -> "World");
+        eventLogWriter.fireCreateEvents(PUBLISHER_EVENT_TYPE, "",
+                asList(eventPayload1, eventPayload2, eventPayload3));
+        List<String> compactionKeys = getPersistedCompactionKeys();
+        assertThat(compactionKeys, contains(equalTo("Hello"), equalTo("World"), nullValue()));
+    }
+
+    @Test
+    public void threeCompactionExtractors() {
+        eventLogWriter.registerCompactionKeyExtractor(PUBLISHER_EVENT_TYPE, MockPayload.class, m -> "Hello");
+        eventLogWriter.registerCompactionKeyExtractor(PUBLISHER_EVENT_TYPE, MockPayload.SubClass.class, m -> "World");
+        eventLogWriter.registerCompactionKeyExtractor(PUBLISHER_EVENT_TYPE, List.class, m -> "List?");
+
+        eventLogWriter.fireCreateEvents(PUBLISHER_EVENT_TYPE, "",
+                asList(eventPayload1, eventPayload2, eventPayload3));
+        List<String> compactionKeys = getPersistedCompactionKeys();
+        assertThat(compactionKeys, contains(equalTo("Hello"), equalTo("World"), equalTo("List?")));
+    }
+
+
+    private List<String> getPersistedCompactionKeys() {
+        verify(eventLogRepository).persist(eventLogsCapture.capture());
+        Collection<EventLog> eventLogs = eventLogsCapture.getValue();
+        List<String> compactionKeys = eventLogs.stream().map(el -> el.getCompactionKey()).collect(toList());
+        return compactionKeys;
+    }
+}

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
@@ -133,10 +133,10 @@ public abstract class EventLogWriterTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 
-    private List<CompactionKeyExtractor<?>> extractorList;
+    private List<CompactionKeyExtractor> extractorList;
     private BiConsumer<String, String> keyAsserter;
 
-    private EventLogWriterTest(BiConsumer<String, String> keyAsserter, CompactionKeyExtractor<?>... extractors) {
+    private EventLogWriterTest(BiConsumer<String, String> keyAsserter, CompactionKeyExtractor... extractors) {
         this.keyAsserter = keyAsserter;
         this.extractorList = List.copyOf(Arrays.asList(extractors));
     }

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/transmission/impl/EventBatcherTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/transmission/impl/EventBatcherTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 public class EventBatcherTest {
     private final ObjectMapper objectMapper = mock(ObjectMapper.class);
     private final Consumer<List<BatchItem>> publisher = mock(Consumer.class);
-    private EventBatcher eventBatcher = new EventBatcher(objectMapper, publisher);
+    private final EventBatcher eventBatcher = new EventBatcher(objectMapper, publisher);
 
     @Test
     public void shouldNotPublishEmptyBatches() {
@@ -74,7 +74,7 @@ public class EventBatcherTest {
         eventBatcher.pushEvent(eventLogEntry1, nakadiEvent1);
         // 30 MB batch size
         eventBatcher.pushEvent(eventLogEntry2, nakadiEvent2);
-        // would be 45MB batch size, wich is more than 80% of 50MB,therefore triggers sumission of the previous two
+        // would be 45MB batch size, which is more than 80% of 50MB, therefore triggers submission of the previous two
         eventBatcher.pushEvent(eventLogEntry3, nakadiEvent3);
 
         verify(publisher)
@@ -95,9 +95,9 @@ public class EventBatcherTest {
                 .thenReturn(new byte[45000000])
                 .thenReturn(new byte[450]);
 
-        // 45 MB batch size => will form a batch of it's own
+        // 45 MB batch size => will form a batch of its own
         eventBatcher.pushEvent(eventLogEntry1, nakadiEvent1);
-        // ... and be sumitted with the next event added
+        // ... and be submitted with the next event added
         eventBatcher.pushEvent(eventLogEntry2, nakadiEvent2);
 
         verify(publisher).accept(eq(singletonList(new BatchItem(eventLogEntry1, nakadiEvent1))));
@@ -125,7 +125,7 @@ public class EventBatcherTest {
     }
 
     private EventLog eventLogEntry(int id, String type) {
-        return new EventLog(id, type, "body", "flow", now(), now(), "me", now());
+        return new EventLog(id, type, "body", "flow", now(), now(), "me", now(), null);
     }
 
     private NakadiEvent nakadiEvent(String eid) {

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionServiceTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionServiceTest.java
@@ -59,7 +59,7 @@ public class EventTransmissionServiceTest {
     public void testWithFlowId() throws JsonProcessingException {
         String flowId = "XYZ";
         String payloadString = mapper.writeValueAsString(Fixture.mockPayload(42, "bla"));
-        EventLog ev = new EventLog(27, "type", payloadString, flowId, now(), now(), null, now().plus(5, MINUTES));
+        EventLog ev = new EventLog(27, "type", payloadString, flowId, now(), now(), null, now().plus(5, MINUTES), null);
 
         service.sendEvents(singletonList(ev));
 
@@ -71,7 +71,7 @@ public class EventTransmissionServiceTest {
     @Test
     public void testWithoutFlowId() throws JsonProcessingException {
         String payloadString = mapper.writeValueAsString(Fixture.mockPayload(42, "bla"));
-        EventLog ev = new EventLog(27, "type", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
+        EventLog ev = new EventLog(27, "type", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
 
         service.sendEvents(singletonList(ev));
 
@@ -83,9 +83,9 @@ public class EventTransmissionServiceTest {
     @Test
     public void testErrorInPayloadDeserializationIsHandledGracefully() throws IOException {
         String payloadString = mapper.writeValueAsString(Fixture.mockPayload(42, "bla"));
-        EventLog ev1 = new EventLog(1, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
-        EventLog ev2 = new EventLog(2, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
-        EventLog ev3 = new EventLog(3, "type2", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
+        EventLog ev1 = new EventLog(1, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
+        EventLog ev2 = new EventLog(2, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
+        EventLog ev3 = new EventLog(3, "type2", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
 
         Mockito.clearInvocations(mapper);
 
@@ -117,9 +117,9 @@ public class EventTransmissionServiceTest {
     @Test
     public void testUnknownErrorInTransmissionIsHandledGracefully() throws Exception {
         String payloadString = mapper.writeValueAsString(Fixture.mockPayload(42, "bla"));
-        EventLog ev1 = new EventLog(1, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
-        EventLog ev2 = new EventLog(2, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
-        EventLog ev3 = new EventLog(3, "type2", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
+        EventLog ev1 = new EventLog(1, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
+        EventLog ev2 = new EventLog(2, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
+        EventLog ev3 = new EventLog(3, "type2", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
 
         doThrow(new IllegalStateException("failed"))
                 .when(publishingClient).publish(eq("type1"), any());
@@ -146,9 +146,9 @@ public class EventTransmissionServiceTest {
     @Test
     public void testEventPublishingExceptionIsHandledGracefully() throws Exception {
         String payloadString = mapper.writeValueAsString(Fixture.mockPayload(42, "bla"));
-        EventLog ev1 = new EventLog(1, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
-        EventLog ev2 = new EventLog(2, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
-        EventLog ev3 = new EventLog(3, "type2", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
+        EventLog ev1 = new EventLog(1, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
+        EventLog ev2 = new EventLog(2, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
+        EventLog ev3 = new EventLog(3, "type2", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
 
         doThrow(new EventPublishingException(new BatchItemResponse[]{
                 new BatchItemResponse("00000000-0000-0000-0000-000000000002", BatchItemResponse.PublishingStatus.ABORTED, BatchItemResponse.Step.ENRICHING, "Something went wrong")
@@ -178,9 +178,9 @@ public class EventTransmissionServiceTest {
     @Test
     public void testWithMultipleEvents() throws JsonProcessingException {
         String payloadString = mapper.writeValueAsString(Fixture.mockPayload(42, "bla"));
-        EventLog ev1 = new EventLog(1, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
-        EventLog ev2 = new EventLog(2, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
-        EventLog ev3 = new EventLog(3, "type2", payloadString, null, now(), now(), null, now().plus(5, MINUTES));
+        EventLog ev1 = new EventLog(1, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
+        EventLog ev2 = new EventLog(2, "type1", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
+        EventLog ev3 = new EventLog(3, "type2", payloadString, null, now(), now(), null, now().plus(5, MINUTES), null);
 
         service.sendEvents(Arrays.asList(ev1, ev2, ev3));
 
@@ -199,7 +199,7 @@ public class EventTransmissionServiceTest {
         // given an event...
         String payloadString = mapper.writeValueAsString(Fixture.mockPayload(42, "bla"));
         // ... whose lock expires in the next minute
-        EventLog ev = new EventLog(27, "type", payloadString, null, now(), now(), null, now().plus(30, SECONDS));
+        EventLog ev = new EventLog(27, "type", payloadString, null, now(), now(), null, now().plus(30, SECONDS), null);
 
         // when the service is asked to send the event
         service.sendEvents(singletonList(ev));
@@ -217,7 +217,7 @@ public class EventTransmissionServiceTest {
         // given an event...
         String payloadString = mapper.writeValueAsString(Fixture.mockPayload(42, "bla"));
         // ... whose lock expires already expired
-        EventLog ev = new EventLog(27, "type", payloadString, null, now(), now(), null, now().minus(1, SECONDS));
+        EventLog ev = new EventLog(27, "type", payloadString, null, now(), now(), null, now().minus(1, SECONDS), null);
 
         // when the service is asked to send the event
         service.sendEvents(singletonList(ev));


### PR DESCRIPTION
This is another implementation of #154, where the user can define the compaction key extractors as spring beans, instead of using a register function on the event log writer (as was done in #158).

This seems to be a more spring-y way of doing this.

Doing this also gave the need/opportunity to rewrite the internal logic of finding the right extractor.

~~Opinions please: is this better or worse than the way in #158?~~

(Most of the commits are the same as in #158, the last ones are the new ones.)

For the change log:

----
* #164: support compacted event types (via spring beans)
  You now can fire events for a compacted event type, by adding a CompactionKeyExtractor spring bean.
----