### PR TITLE
Batch deletion of eventlogs

### DIFF
--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryImpl.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryImpl.java
@@ -61,11 +61,19 @@ public class EventLogRepositoryImpl implements EventLogRepository {
 
     @Override
     public void delete(EventLog eventLog) {
-        Map<String, Object> namedParameterMap = new HashMap<>();
-        namedParameterMap.put("id", eventLog.getId());
-        jdbcTemplate.update(
-            "DELETE FROM nakadi_events.event_log where id = :id",
-            namedParameterMap
+        delete(Collections.singleton(eventLog));
+    }
+
+    @Override
+    public void delete(Collection<EventLog> eventLogs) {
+        MapSqlParameterSource[] namedParameterMaps = eventLogs.stream()
+                .map(eventLog ->
+                    new MapSqlParameterSource().addValue("id", eventLog.getId())
+                ).toArray(MapSqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(
+                "DELETE FROM nakadi_events.event_log where id = :id",
+                namedParameterMaps
         );
     }
 

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepository.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepository.java
@@ -10,6 +10,10 @@ public interface EventLogRepository {
 
     void delete(EventLog eventLog);
 
+    default void delete(Collection<EventLog> eventLogs) {
+        eventLogs.forEach(this::delete);
+    }
+
     void persist(EventLog eventLog);
 
     default void persist(Collection<EventLog> eventLogs) {

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionService.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/EventTransmissionService.java
@@ -116,7 +116,7 @@ public class EventTransmissionService {
                             .filter(rawEvent -> !failedEids.contains(convertToUUID(rawEvent.getId())));
         }
 
-        successfulEvents.forEach(eventLogRepository::delete);
+        eventLogRepository.delete(successfulEvents.collect(Collectors.toList()));
     }
 
     private List<String> collectEids(EventPublishingException e) {


### PR DESCRIPTION
* repository: add batch deletion method to interface (with default implementation)
* repository: implement batch deletion (uses updateBatch)
* test for batch deletion
* ~repository: refactoring for persist~
* transmission: use batch deletion

This came up as a part of #170, but seems useful enough without it, so I'm submitting this as a separate PR.