### PR TITLE
Add DELETE permission to the eventlog table.

### DIFF
--- a/nakadi-producer-spring-boot-starter/src/main/resources/db_nakadiproducer/migrations/V2/V2133546886.1.2__grant_delete_permissions.sql
+++ b/nakadi-producer-spring-boot-starter/src/main/resources/db_nakadiproducer/migrations/V2/V2133546886.1.2__grant_delete_permissions.sql
@@ -1,0 +1,1 @@
+GRANT DELETE ON nakadi_events.event_log TO PUBLIC;


### PR DESCRIPTION
Without this, an application user who is not owner of the database/table (or superuser) can't delete events after sending them out.

Fixes #101.

I just stumbled over this in my PoC application for #170, and then found this issue from 5 years ago.