### PR TITLE
use Zonky embedded postgres instead of opentable one for tests.

### DIFF
--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
@@ -73,16 +72,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.opentable.components</groupId>
-            <artifactId>otj-pg-embedded</artifactId>
-            <version>0.7.1</version>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <version>2.0.4</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>postgresql</artifactId>
-                    <groupId>postgresql</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
@@ -108,11 +101,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jdbc</artifactId>
-            <version>5.3.12</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/FlywayDataSourceIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/FlywayDataSourceIT.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 
 @ContextConfiguration(classes=FlywayDataSourceIT.Config.class)
 public class FlywayDataSourceIT extends BaseMockedExternalCommunicationIT {

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/config/EmbeddedDataSourceConfig.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/config/EmbeddedDataSourceConfig.java
@@ -1,7 +1,7 @@
 package org.zalando.nakadiproducer.config;
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;


### PR DESCRIPTION
This allows to use a newer postgresql version without much other changes.

The otj-pg-embedded 0.7.1 was using postgresql 9.5, which is outdated for several years, and doesn't know `CREATE PUBLICATION` (which I wanted to add to #174).

Current versions of otj-pg-embedded use docker images, which I didn't want to go into.