### PR TITLE
spring-boot-2-test: add a fixed version of junit4.

### DIFF
--- a/nakadi-producer-starter-spring-boot-2-test/pom.xml
+++ b/nakadi-producer-starter-spring-boot-2-test/pom.xml
@@ -58,6 +58,20 @@
             <artifactId>system-rules</artifactId>
             <version>1.19.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit-dep</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Including a fixed version of junit-dep directly, to avoid system-rules
+             fetching the latest version dynamically. -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit-dep</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
This prevents Maven from trying to dynamically fetch a transitive dependency each time.

This always broke the build when my VPN was not enabled.